### PR TITLE
v1.2.1 — fix WS reattach for REST-created sessions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8831,7 +8831,7 @@
     },
     "packages/proxy": {
       "name": "green-screen-proxy",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "cors": "^2.8.5",
@@ -8852,7 +8852,7 @@
     },
     "packages/react": {
       "name": "green-screen-react",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "devDependencies": {
         "@testing-library/jest-dom": "^6.6.3",
@@ -8874,11 +8874,11 @@
     },
     "packages/standalone": {
       "name": "green-screen-terminal",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "express": "^4.21.0",
-        "green-screen-proxy": "^1.2.0"
+        "green-screen-proxy": "^1.2.1"
       },
       "bin": {
         "green-screen-terminal": "bin/green-screen-terminal.js"
@@ -8886,7 +8886,7 @@
     },
     "packages/types": {
       "name": "green-screen-types",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT"
     }
   }

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "green-screen-proxy",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "WebSocket/REST proxy server for green-screen-react — connects browsers to TN5250, TN3270, VT220, and HP 6530 hosts over TCP",
   "type": "module",
   "bin": {

--- a/packages/proxy/src/controller.ts
+++ b/packages/proxy/src/controller.ts
@@ -79,6 +79,21 @@ export class SessionController {
     return this.handler;
   }
 
+  /**
+   * Adopt an already-connected ProtocolHandler owned by another holder
+   * (e.g. a REST-created Session). Wires this controller up to dispatch
+   * key/text/setCursor commands against the existing handler without
+   * re-binding connection-level event listeners — the owning Session
+   * remains responsible for the handler lifecycle.
+   *
+   * Used by the WebSocket reattach path so WS clients can drive a session
+   * that was originally created via REST.
+   */
+  adoptHandler(handler: ProtocolHandler): void {
+    this.handler = handler;
+    this.connected = true;
+  }
+
   handleText(text: string): void {
     if (!this.handler || !this.connected) {
       this.send({ type: 'error', message: 'Not connected' });

--- a/packages/proxy/src/websocket.ts
+++ b/packages/proxy/src/websocket.ts
@@ -238,6 +238,22 @@ async function handleWsCommand(ws: WebSocket, client: WsClient, msg: any): Promi
           }
           unassignedClients.delete(client);
           indexClient(client);
+          // Adopt the REST session's handler into a SessionController so
+          // subsequent WS key/text/setCursor commands from this client have
+          // a controller to dispatch through. Without this, the `case 'key'`
+          // branch would see `client.controller == null` and reply with
+          // "Not connected", silently dropping every keystroke from
+          // interactive clients that reattach to REST-created sessions.
+          const adoptedController = new SessionController((m) => {
+            wsSend(ws, m);
+            // Mirror the `connect` path: broadcast screen updates to other
+            // clients watching the same session so dashboards stay in sync.
+            if (client.sessionId && ('type' in m) && (m as any).type === 'screen') {
+              broadcastToSession(client.sessionId, JSON.stringify(m), ws);
+            }
+          });
+          adoptedController.adoptHandler(session.handler);
+          client.controller = adoptedController;
           wsSend(ws, { type: 'screen', data: session.getScreenData() });
           wsSend(ws, { type: 'status', data: session.status });
           wsSend(ws, { type: 'connected', sessionId: session.id });

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "green-screen-react",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Multi-protocol legacy terminal React component (TN5250, TN3270, VT, HP 6530)",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/standalone/package.json
+++ b/packages/standalone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "green-screen-terminal",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Standalone web-based terminal for TN5250, TN3270, VT220, and HP 6530 hosts — run with npx green-screen-terminal",
   "type": "module",
   "bin": {
@@ -14,7 +14,7 @@
     "build:ui": "cd ../../apps/demo && VITE_BASE_URL=/ npx vite build --outDir ../../packages/standalone/ui"
   },
   "dependencies": {
-    "green-screen-proxy": "^1.2.0",
+    "green-screen-proxy": "^1.2.1",
     "express": "^4.21.0"
   },
   "keywords": [

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "green-screen-types",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Shared type definitions for green-screen-react and green-screen-proxy",
   "type": "module",
   "main": "src/index.ts",


### PR DESCRIPTION
## Summary

- **fix(proxy):** adopt REST session handler on WS reattach. When a WebSocket client reattached to a session created via the REST `/connect` endpoint, the reattach branch set `client.sessionId` but never assigned `client.controller`, so subsequent `key` / `text` / `setCursor` WS commands hit `if (!controller) 'Not connected'` and were silently dropped.
- Adds `SessionController.adoptHandler()` to wrap an already-connected `ProtocolHandler` owned by another holder (the REST `Session`) without re-binding connection-lifecycle listeners. The reattach REST-session branch now builds a controller around the existing handler, mirroring the `case 'connect'` broadcast pattern so other session watchers still see screen updates.
- **chore(release):** bump `green-screen-types`, `green-screen-react`, `green-screen-proxy`, `green-screen-terminal` to 1.2.1. `green-screen-terminal` dependency on `green-screen-proxy` bumped to `^1.2.1`.

## Impact

Integrators where an auth-owning backend creates sessions via REST and a browser drives them through the WS adapter (e.g. LegacyBridge) were unable to use the interactive terminal on 1.2.0 — Tab, Backspace, Enter, arrows, and character input all silently failed. This release fixes that.

No API changes. `green-screen-client` (Python) remains on its independent PyPI release cadence.

## Test plan

- [x] `npm run test -w packages/react` — 59 passed
- [x] `npm run build -w packages/react` — green
- [x] `npm run build -w packages/proxy` — green
- [x] `npm run build:ui -w packages/standalone` — green
- [x] `tsc --noEmit` on proxy — clean
- [ ] CI green on PR
- [ ] Manual: LegacyBridge interactive terminal — Tab, Backspace, characters round-trip after bumping to 1.2.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)