### PR TITLE
v1.2.2 — graceful proxy shutdown (drain host sessions on SIGTERM)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8831,7 +8831,7 @@
     },
     "packages/proxy": {
       "name": "green-screen-proxy",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "license": "MIT",
       "dependencies": {
         "cors": "^2.8.5",
@@ -8852,7 +8852,7 @@
     },
     "packages/react": {
       "name": "green-screen-react",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "license": "MIT",
       "devDependencies": {
         "@testing-library/jest-dom": "^6.6.3",
@@ -8874,11 +8874,11 @@
     },
     "packages/standalone": {
       "name": "green-screen-terminal",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "license": "MIT",
       "dependencies": {
         "express": "^4.21.0",
-        "green-screen-proxy": "^1.2.1"
+        "green-screen-proxy": "^1.2.2"
       },
       "bin": {
         "green-screen-terminal": "bin/green-screen-terminal.js"
@@ -8886,7 +8886,7 @@
     },
     "packages/types": {
       "name": "green-screen-types",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "license": "MIT"
     }
   }

--- a/packages/client-py/pyproject.toml
+++ b/packages/client-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "green-screen-client"
-version = "1.2.1"
+version = "1.2.2"
 description = "Python client for green-screen-proxy — typed async REST + WebSocket adapter for TN5250/TN3270/VT/HP6530 terminal emulation"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "green-screen-proxy",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "WebSocket/REST proxy server for green-screen-react — connects browsers to TN5250, TN3270, VT220, and HP 6530 hosts over TCP",
   "type": "module",
   "bin": {

--- a/packages/proxy/src/index.ts
+++ b/packages/proxy/src/index.ts
@@ -50,7 +50,7 @@ export async function createProxy(options: ProxyOptions = {}): Promise<ProxyServ
   app.use(cors());
   app.use(express.json());
 
-  const [{ default: routes }, { setupWebSocket }] = await Promise.all([
+  const [{ default: routes }, { setupWebSocket, shutdownAllWsControllers }] = await Promise.all([
     import('./routes.js'),
     import('./websocket.js'),
   ]);
@@ -84,10 +84,30 @@ export async function createProxy(options: ProxyOptions = {}): Promise<ProxyServ
         server,
         app,
         port: resolvedPort,
-        close() {
-          return new Promise<void>((res) => {
+        async close() {
+          // Drain live host connections BEFORE closing the HTTP server so
+          // each TCP socket has a chance to send a clean FIN upstream.
+          // Without this, abrupt process termination leaves host-side
+          // resources dangling (e.g. IBM i virtual telnet device
+          // descriptions stuck in VARY ON PENDING, blocking device-
+          // restricted user profiles from signing on again).
+          try {
+            // 1. REST-created sessions tracked by the session store.
+            const { getSessionStore } = await import('./session-store.js');
+            for (const session of Array.from(getSessionStore().values())) {
+              try { session.destroy(); } catch { /* ignore */ }
+            }
+            // 2. WS-created SessionControllers (live + orphaned).
+            shutdownAllWsControllers();
+          } catch { /* ignore */ }
+
+          await new Promise<void>((res) => {
             server.close(() => res());
-            setTimeout(() => res(), 1000);
+            // Safety timeout — give in-flight HTTP requests up to 5s to
+            // finish before forcing exit. Session TCP FINs are sent
+            // synchronously above, so the host has already started its
+            // cleanup by the time this fires.
+            setTimeout(() => res(), 5000);
           });
         },
       });

--- a/packages/proxy/src/server.ts
+++ b/packages/proxy/src/server.ts
@@ -6,10 +6,29 @@ const proxy = await createProxy({ port: PORT });
 
 console.log(`Green Screen proxy server running on http://localhost:${proxy.port}`);
 
-function shutdown() {
-  proxy.close().then(() => process.exit(0));
-  setTimeout(() => process.exit(0), 1000);
+let shuttingDown = false;
+function shutdown(signal: string) {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  console.log(`[proxy] Received ${signal}, draining sessions...`);
+  proxy.close()
+    .then(() => {
+      console.log('[proxy] Shutdown complete');
+      process.exit(0);
+    })
+    .catch((err) => {
+      console.error('[proxy] Error during shutdown:', err);
+      process.exit(1);
+    });
+  // Safety net: if close() hangs for any reason, force exit after 8s.
+  // Docker's default SIGTERM grace period is 10s, so leave headroom
+  // below that. Session drain itself is synchronous (socket.end() is
+  // non-blocking); the HTTP server.close() is what can take time.
+  setTimeout(() => {
+    console.error('[proxy] Shutdown timeout, forcing exit');
+    process.exit(1);
+  }, 8000);
 }
 
-process.on('SIGINT', shutdown);
-process.on('SIGTERM', shutdown);
+process.on('SIGINT', () => shutdown('SIGINT'));
+process.on('SIGTERM', () => shutdown('SIGTERM'));

--- a/packages/proxy/src/websocket.ts
+++ b/packages/proxy/src/websocket.ts
@@ -6,7 +6,7 @@ import {
   getDefaultSession,
   destroySession,
 } from './session.js';
-import { sessionLifecycle } from './session-store.js';
+import { sessionLifecycle, getSessionStore } from './session-store.js';
 import { SessionController } from './controller.js';
 import type { ProtocolType } from './protocols/index.js';
 import type { ConnectionStatus } from 'green-screen-types';
@@ -342,4 +342,44 @@ function broadcastToSession(sessionId: string, message: string, exclude?: WebSoc
 export function broadcastScreenToSession(sessionId: string, screenData: object): void {
   const message = JSON.stringify({ type: 'screen', data: screenData });
   broadcastToSession(sessionId, message);
+}
+
+/**
+ * Disconnect every SessionController held by this module so their TCP
+ * sockets send a clean FIN to the upstream host before the process exits.
+ *
+ * The HTTP `createProxy().close()` path calls this during graceful
+ * shutdown. Without it, TCP connections to legacy hosts are torn down
+ * abruptly on process exit, which on IBM i leaves virtual telnet device
+ * descriptions stuck in `VARY ON PENDING` until a host-side timer
+ * reclaims them — blocking subsequent sign-ons from device-restricted
+ * user profiles.
+ *
+ * Covers both live controllers bound to an active WS client and
+ * orphaned controllers whose WS dropped but whose TCP is still alive
+ * (kept for potential reattach). Adopted controllers (WS reattaches to
+ * a REST-owned Session) are intentionally left alone — the REST
+ * Session owns the handler lifecycle and is drained separately by
+ * iterating the session store.
+ */
+export function shutdownAllWsControllers(): void {
+  for (const [sessionId, orphan] of orphanedControllers) {
+    try { orphan.handleDisconnect(); } catch { /* ignore */ }
+    orphanedControllers.delete(sessionId);
+  }
+  for (const client of clients) {
+    const ctrl = client.controller;
+    if (!ctrl) continue;
+    // Skip adopted controllers — they wrap a REST Session's handler,
+    // which the session store drain will disconnect. Adopted
+    // controllers have `connected=true` but no owned handler lifecycle.
+    // We detect them by checking whether the handler is owned by a
+    // Session in the store (same instance).
+    const ownedByRestSession = client.sessionId
+      ? getSessionStore().get(client.sessionId)?.handler === (ctrl as any).handler
+      : false;
+    if (ownedByRestSession) continue;
+    try { ctrl.handleDisconnect(); } catch { /* ignore */ }
+    client.controller = null;
+  }
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "green-screen-react",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Multi-protocol legacy terminal React component (TN5250, TN3270, VT, HP 6530)",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/standalone/package.json
+++ b/packages/standalone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "green-screen-terminal",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Standalone web-based terminal for TN5250, TN3270, VT220, and HP 6530 hosts — run with npx green-screen-terminal",
   "type": "module",
   "bin": {
@@ -14,7 +14,7 @@
     "build:ui": "cd ../../apps/demo && VITE_BASE_URL=/ npx vite build --outDir ../../packages/standalone/ui"
   },
   "dependencies": {
-    "green-screen-proxy": "^1.2.1",
+    "green-screen-proxy": "^1.2.2",
     "express": "^4.21.0"
   },
   "keywords": [

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "green-screen-types",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Shared type definitions for green-screen-react and green-screen-proxy",
   "type": "module",
   "main": "src/index.ts",


### PR DESCRIPTION
## Summary

- **fix(proxy):** `createProxy().close()` now drains all active host TCP connections before closing the HTTP server. Prior behavior left sockets dangling until OS reap → TCP RST → IBM i devices stuck in `VARY ON PENDING` → subsequent sign-ons from device-restricted user profiles fail with CPF2241/CPF1110. Covers all three session holders: REST sessions in the session store, live WS `SessionController`s, and orphaned controllers (kept alive for reattach).
- **chore(release):** bump all 5 packages to 1.2.2 for lockstep versioning.

## Impact

Any deployment that restarts the proxy container (docker restart, CI rollouts, manual updates) while clients are connected. On IBM i this was acute: a single bounce would lock out device-restricted user profiles until an operator manually varied devices off/on. Other legacy hosts may also hold resources on abrupt TCP drops; graceful shutdown is the safer default regardless.

Discovered the hard way during the 1.2.1 rollout on a LegacyBridge Hetzner deployment — restarting the proxy with an active session burned through the `TNDEV*` device pool and tripped IBM i's CPF1116 throttle.

## Test plan

- [x] `tsc --noEmit` clean for proxy
- [x] `npm run build -w packages/proxy` green
- [x] `npm run build -w packages/react` + `npm run test -w packages/react` (59 tests pass)
- [x] `npm run build:ui -w packages/standalone` green
- [x] **Live smoke test**: start proxy on port 3099, connect a REST session to pub400.com, send SIGTERM. Logs confirmed the drain fired: `Received SIGTERM, draining sessions... → Disconnecting socket to 185.113.5.134:23 → Shutdown complete` (clean FIN before process exit).
- [ ] CI green on PR
- [ ] End-to-end on Hetzner: restart proxy with live session, confirm IBM i devices do NOT get stuck in `VARY ON PENDING` and reconnect succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)