### PR TITLE
v1.3.0 — demo polish, terminal pluggability, proxy robustness

### DIFF
--- a/apps/demo/src/App.css
+++ b/apps/demo/src/App.css
@@ -5,34 +5,161 @@
 }
 
 body {
-  background: #0a0a0a;
-  color: #e2e8f0;
-  font-family: 'IBM Plex Mono', 'Courier New', monospace;
+  background: #11111b;
+  color: #cdd6f4;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
   min-height: 100vh;
+  transition: background 0.3s ease;
+}
+
+/* Theme-driven body background: lets the demo page feel consistent with
+ * whichever terminal palette is selected. Classic = dark gray that's
+ * slightly LIGHTER than the terminal's own pure-black background — so
+ * the terminal visibly "pops" against the page. */
+body.gs-demo-theme-classic {
+  background: #1a1a1a;
+}
+body.gs-demo-theme-modern {
+  background: #11111b;
+}
+
+/* Classic theme: phosphor-CRT look extends to page chrome — the
+ * "green-screen-react" title and the npx install command pill pick up
+ * the same green glow the terminal uses. */
+body.gs-demo-theme-classic .demo-title {
+  color: #29fa29;
+  font-family: 'JetBrains Mono', 'Courier New', monospace;
+  text-shadow: 0 0 8px rgba(41, 250, 41, 0.35);
+  letter-spacing: 0.02em;
+}
+
+body.gs-demo-theme-classic .install-cmd-wrap {
+  background: #000000;
+  border-color: #1a1a1a;
+}
+
+body.gs-demo-theme-classic .install-cmd {
+  color: #29fa29;
+  text-shadow: 0 0 6px rgba(41, 250, 41, 0.35);
+}
+
+body.gs-demo-theme-classic .copy-btn.copied {
+  color: #29fa29;
+  border-color: rgba(41, 250, 41, 0.4);
+  background: rgba(41, 250, 41, 0.08);
 }
 
 .demo-page {
   max-width: 920px;
   margin: 0 auto;
-  padding: 2rem 1rem;
+  padding: 2.5rem 1rem;
+  /* Flex column so the fit-to-content .terminal-wrapper child centers
+   * horizontally via align-items. Previously it hugged the left edge in
+   * the block-layout flow. Header/footer stay full-width via
+   * align-self: stretch where needed. */
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.demo-page > * {
+  width: 100%;
+  max-width: 920px;
+}
+
+/* Terminal wrapper stays fit-to-content — width:auto overrides the 100%
+ * rule above so the box hugs the 80×24 terminal, not the full column.
+ * The theme-picker pill and the terminal-block (which wraps the terminal
+ * and its footer) get the same treatment so they don't stretch. */
+.demo-page > .terminal-wrapper,
+.demo-page > .theme-picker,
+.demo-page > .terminal-block {
+  width: auto;
+  max-width: none;
+}
+
+/* Terminal block: hugs the terminal's scaled width so the chrome above/
+ * below (install-cmd + GitHub, theme toggle) aligns to the terminal's
+ * own edges instead of the full 920px page column. `display: inline-flex`
+ * makes the container auto-size to its widest child (the zoomed
+ * terminal). `position: relative` anchors the absolute-positioned
+ * `.connect-info` heading to the block's top-left corner. */
+.terminal-block {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 1rem;
+  position: relative;
 }
 
 .demo-header {
-  text-align: center;
-  margin-bottom: 1.5rem;
+  text-align: left;
+  margin-bottom: 0.5rem;
+}
+
+/* Header row: title + subtitle on the LEFT (stacked), GitHub + npx on
+ * the RIGHT (stacked). Both inner columns use space-between to pin the
+ * first item to the TOP and the last item to the BOTTOM — so GitHub
+ * lines up with the title and npx lines up with the subtitle. */
+.demo-header-row {
+  display: flex;
+  align-items: stretch;
+  justify-content: space-between;
+  gap: 1rem;
+  width: 100%;
+}
+
+.demo-header-text {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 0.25rem;
 }
 
 .demo-title {
   font-size: 2rem;
-  font-weight: 600;
-  color: #33ff33;
-  letter-spacing: -0.02em;
+  font-weight: 700;
+  color: #cba6f7;
+  letter-spacing: -0.03em;
+  white-space: nowrap;
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+/* Small capsule label displayed next to the title to flag the page as
+ * a live demo / preview of the package. Renders as an outlined pill
+ * with uppercase tracked lettering; picks up theme colors for the
+ * border and text so it harmonises with the rest of the header. */
+.demo-title-badge {
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  padding: 3px 8px;
+  border: 1px solid currentColor;
+  border-radius: 999px;
+  color: #cba6f7;
+  opacity: 0.7;
+  line-height: 1;
+  white-space: nowrap;
+  /* Nudge down so the badge's optical center aligns with the title's
+   * x-height rather than its cap-height (feels more balanced next to
+   * the descender-heavy "@green-screen-react"). */
+  transform: translateY(2px);
+}
+
+body.gs-demo-theme-classic .demo-title-badge {
+  color: #29fa29;
+  border-radius: 0;
+  text-shadow: 0 0 4px rgba(41, 250, 41, 0.35);
 }
 
 .demo-subtitle {
   font-size: 0.875rem;
-  color: #6b7280;
-  margin-top: 0.25rem;
+  color: #6c7086;
+  margin-top: 0.375rem;
+  font-weight: 400;
 }
 
 /* ── Protocol tabs ─────────────────────────── */
@@ -42,36 +169,35 @@ body {
   gap: 0;
   justify-content: center;
   margin-bottom: 0;
-  border-bottom: 1px solid #1e1e1e;
+  border-bottom: 1px solid #313244;
 }
 
 .protocol-tab {
   background: none;
   border: none;
-  color: #6b7280;
+  color: #6c7086;
   font-family: inherit;
   font-size: 0.8rem;
   font-weight: 500;
   padding: 0.5rem 1.25rem;
   cursor: pointer;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
+  letter-spacing: 0.02em;
   border-bottom: 2px solid transparent;
   transition: color 0.15s, border-color 0.15s;
 }
 
 .protocol-tab:hover {
-  color: #a0a0a0;
+  color: #a6adc8;
 }
 
 .protocol-tab.active {
-  color: #33ff33;
-  border-bottom-color: #33ff33;
+  color: #cba6f7;
+  border-bottom-color: #cba6f7;
 }
 
 .connect-tab.active {
-  color: #60a5fa;
-  border-bottom-color: #60a5fa;
+  color: #89b4fa;
+  border-bottom-color: #89b4fa;
 }
 
 /* ── Demo hint ─────────────────────────────── */
@@ -79,47 +205,276 @@ body {
 .demo-hint {
   text-align: center;
   font-size: 0.75rem;
-  color: #4b5563;
+  color: #585b70;
   padding: 0.5rem 0;
-  letter-spacing: 0.03em;
 }
 
 /* ── Terminal wrapper ──────────────────────── */
 
+/* Fit-to-content: wrap sizes to the terminal's inner render area instead
+ * of stretching to the full page width. The flex container centers it.
+ * `position: relative` anchors the theme sticker at the top-right.
+ *
+ * `zoom: 1.2` makes the terminal render ~20% larger than the pixel-exact
+ * 80×24 grid — more readable without distorting the cursor/click math
+ * (zoom scales layout including pointer coordinates, unlike transform
+ * scale). Supported in Chrome/Safari/Edge and modern Firefox. */
 .terminal-wrapper {
-  border-radius: 8px;
-  overflow: hidden;
-  box-shadow: 0 0 40px rgba(51, 255, 51, 0.05);
+  border-radius: 10px;
+  display: inline-flex;
+  position: relative;
+  zoom: 1.2;
+}
+
+/* ── Theme sticker ─────────────────────────── */
+
+/* Theme sticker: positioned BELOW the terminal (not overlapping header/
+ * footer). Per-theme visual variants below. z-index keeps it above the
+ * terminal border/shadow. `pointer-events: none` makes it click-through
+ * so the terminal below still receives clicks. */
+.theme-sticker {
+  position: absolute;
+  bottom: -64px;
+  z-index: 20;
+  padding: 10px 16px;
+  min-width: 170px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  line-height: 1.15;
+  pointer-events: none;
+  user-select: none;
+  transition: transform 0.25s ease, background 0.3s ease, color 0.3s ease;
+}
+
+.theme-sticker-line1 {
+  font-size: 1.05rem;
+  font-weight: 700;
+}
+
+.theme-sticker-line2 {
+  font-size: 0.82rem;
+  opacity: 0.85;
+  margin-top: 2px;
+}
+
+/* ── Classic: paper sticky-note, right side, tilted, taped on ── */
+
+.theme-sticker-classic {
+  right: 24px;
+  left: auto;
+  background: linear-gradient(135deg, #fff3c4 0%, #ffd868 100%);
+  color: #6b4a00;
+  font-family: 'Caveat', 'Comic Sans MS', 'Bradley Hand', cursive;
+  border-radius: 3px;
+  transform: rotate(-4deg);
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.3),
+    0 8px 20px rgba(0, 0, 0, 0.45);
+}
+
+/* Translucent tape strip at the top center — attaches the note to the
+ * terminal above it. Slightly offset rotation makes it feel hand-applied. */
+.theme-sticker-classic::before {
+  content: '';
+  position: absolute;
+  top: -10px;
+  left: 50%;
+  transform: translateX(-50%) rotate(3deg);
+  width: 58px;
+  height: 18px;
+  background: linear-gradient(180deg,
+    rgba(230, 220, 180, 0.5) 0%,
+    rgba(210, 200, 160, 0.65) 100%);
+  border: 1px solid rgba(170, 160, 120, 0.4);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.15);
+}
+
+/* ── Modern: brushed-metal panel, left side, flat, four screws ── */
+
+.theme-sticker-modern {
+  /* Positioned so the nameplate hangs just below the terminal edge,
+   * clearing the header while staying visually "attached" to the chrome.
+   * Darker brushed-metal palette — reads as gunmetal/anthracite rather
+   * than polished silver, so the panel sits against the page background
+   * without glowing. */
+  bottom: -59px;
+  left: 24px;
+  right: auto;
+  background: linear-gradient(145deg, #4a4f58 0%, #5a6069 40%, #3a3e46 100%);
+  color: #e6e9ee;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+  border: 1px solid #2a2d33;
+  border-radius: 4px;
+  transform: none;
+  padding: 16px 22px;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.15),
+    inset 0 -1px 0 rgba(0, 0, 0, 0.35),
+    0 2px 4px rgba(0, 0, 0, 0.35),
+    0 10px 18px rgba(0, 0, 0, 0.4);
+}
+
+.theme-sticker-modern .theme-sticker-line1 {
+  letter-spacing: 0.02em;
+}
+.theme-sticker-modern .theme-sticker-line2 {
+  color: #b8bcc4;
+}
+
+/* Screw heads: small gray circles inset into the metal corners. Radial
+ * gradient simulates a tiny highlight on the top-left of each screw. */
+.sticker-screw {
+  position: absolute;
+  width: 8px;
+  height: 8px;
+  background: radial-gradient(circle at 35% 35%,
+    #6c7079 0%, #4a4e55 55%, #2d3036 100%);
+  border-radius: 50%;
+  box-shadow: inset 0 0.5px 0.5px rgba(255, 255, 255, 0.35);
+}
+.sticker-screw-tl { top: 5px; left: 5px; }
+.sticker-screw-tr { top: 5px; right: 5px; }
+.sticker-screw-bl { bottom: 5px; left: 5px; }
+.sticker-screw-br { bottom: 5px; right: 5px; }
+
+/* Parent row that centers the fit-to-content wrapper. */
+.connect-form,
+.standalone-page {
+  display: flex;
+  justify-content: center;
 }
 
 /* ── Connect panel ─────────────────────────── */
 
-.connect-panel {
-  padding: 1.5rem;
+/* .connect-panel is no longer emitted — ConnectPanel returns a Fragment
+ * with .connect-info + .connect-form as direct children of .terminal-block.
+ * Keeping the old rule here would apply 1.5rem of dead padding. */
+
+/* Info block holds only the heading + info-tooltip trigger. Absolutely
+ * positioned so it straddles the terminal's top-left CORNER — centered
+ * on the top edge with a matching page-bg background so the heading
+ * visually "cuts" through the terminal's border at the corner, like a
+ * tag attached there. */
+.connect-info {
+  position: absolute;
+  /* Sits INSIDE the terminal's top-left area — no background pill, just
+   * the heading text sitting against the terminal's dark surface.
+   * Offset clears the header row (~68px) + gap (16px) + ~25px inside
+   * the terminal's top edge. */
+  top: 117px;
+  left: 20px;
+  z-index: 10;
+  margin: 0;
+  padding: 0;
+  background: transparent;
 }
 
-.connect-info {
-  margin-bottom: 1.5rem;
+.connect-heading {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: #cdd6f4;
+}
+
+/* Info-tooltip button: small (i) icon after the heading. Hovering or
+ * focusing it reveals the .info-tooltip bubble positioned below. */
+.info-tooltip-btn {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  background: transparent;
+  border: 1px solid #313244;
+  border-radius: 50%;
+  color: #6c7086;
+  cursor: help;
+  transition: color 0.15s, border-color 0.15s, background 0.15s;
+}
+
+.info-tooltip-btn:hover,
+.info-tooltip-btn:focus-visible {
+  color: #cdd6f4;
+  border-color: #45475a;
+  background: rgba(205, 214, 244, 0.04);
+  outline: none;
+}
+
+.info-tooltip {
+  position: absolute;
+  top: calc(100% + 10px);
+  left: 0;
+  z-index: 30;
+  width: 380px;
+  max-width: 85vw;
+  padding: 0.75rem 0.9rem;
+  background: #181825;
+  color: #a6adc8;
+  border: 1px solid #313244;
+  border-radius: 6px;
+  font-size: 0.8rem;
+  font-weight: 400;
+  line-height: 1.5;
+  text-align: left;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.4);
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(-4px);
+  transition: opacity 0.18s ease, transform 0.18s ease, visibility 0.18s;
+  pointer-events: none;
+}
+
+.info-tooltip-btn:hover .info-tooltip,
+.info-tooltip-btn:focus-visible .info-tooltip {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+}
+
+/* Classic theme: tooltip adopts the stark black/gray palette. */
+body.gs-demo-theme-classic .info-tooltip-btn {
+  border-color: #1a1a1a;
+  color: #8a8a8a;
+}
+body.gs-demo-theme-classic .info-tooltip-btn:hover,
+body.gs-demo-theme-classic .info-tooltip-btn:focus-visible {
+  color: #e0e0e0;
+  border-color: #333333;
+  background: rgba(255, 255, 255, 0.04);
+}
+body.gs-demo-theme-classic .info-tooltip {
+  background: #0a0a0a;
+  color: #cfcfcf;
+  border-color: #1f1f1f;
 }
 
 .connect-info h3 {
   font-size: 1rem;
-  color: #e2e8f0;
+  color: #cdd6f4;
   margin-bottom: 0.5rem;
+  font-weight: 600;
 }
 
 .connect-info p {
   font-size: 0.8rem;
-  color: #6b7280;
-  line-height: 1.5;
+  color: #6c7086;
+  line-height: 1.6;
 }
 
 .connect-info code {
-  background: #161616;
-  color: #33ff33;
+  background: #181825;
+  color: #cba6f7;
   padding: 0.15rem 0.4rem;
-  border-radius: 3px;
+  border-radius: 4px;
   font-size: 0.75rem;
+  font-family: 'JetBrains Mono', 'Courier New', monospace;
 }
 
 .connect-steps {
@@ -134,7 +489,7 @@ body {
   align-items: flex-start;
   gap: 0.75rem;
   font-size: 0.8rem;
-  color: #9ca3af;
+  color: #a6adc8;
 }
 
 .step-num {
@@ -144,8 +499,8 @@ body {
   min-width: 22px;
   height: 22px;
   border-radius: 50%;
-  background: #1e1e1e;
-  color: #33ff33;
+  background: #313244;
+  color: #cba6f7;
   font-size: 0.7rem;
   font-weight: 600;
   flex-shrink: 0;
@@ -153,17 +508,18 @@ body {
 
 .step code {
   display: block;
-  background: #161616;
-  color: #33ff33;
+  background: #181825;
+  color: #cba6f7;
   padding: 0.15rem 0.4rem;
-  border-radius: 3px;
+  border-radius: 4px;
   font-size: 0.75rem;
+  font-family: 'JetBrains Mono', 'Courier New', monospace;
   margin-bottom: 0.25rem;
 }
 
 .step-desc {
   font-size: 0.7rem;
-  color: #4b5563;
+  color: #585b70;
 }
 
 .connect-form {
@@ -175,9 +531,8 @@ body {
 .connect-label {
   display: block;
   font-size: 0.7rem;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-  color: #6b7280;
+  letter-spacing: 0.05em;
+  color: #6c7086;
 }
 
 .connect-input {
@@ -185,32 +540,33 @@ body {
   width: 100%;
   margin-top: 0.25rem;
   padding: 0.5rem 0.625rem;
-  background: rgba(16, 185, 129, 0.05);
-  border: 1px solid #1e293b;
-  color: #33ff33;
-  font-family: inherit;
+  background: rgba(203, 166, 247, 0.05);
+  border: 1px solid #313244;
+  color: #cdd6f4;
+  font-family: 'JetBrains Mono', 'Courier New', monospace;
   font-size: 0.85rem;
   outline: none;
-  border-radius: 3px;
+  border-radius: 6px;
+  transition: border-color 0.15s;
 }
 
 .connect-input:focus {
-  border-color: #33ff33;
+  border-color: #cba6f7;
 }
 
 .connect-input::placeholder {
-  color: #374151;
+  color: #45475a;
 }
 
 .connect-note {
   margin-top: 0.75rem;
   font-size: 0.7rem;
-  color: #4b5563;
+  color: #585b70;
   font-style: italic;
 }
 
 .connect-error {
-  color: #ef4444;
+  color: #f38ba8;
   font-size: 0.75rem;
   font-family: inherit;
 }
@@ -221,61 +577,307 @@ body {
 }
 
 .connect-status.connected {
-  color: #33ff33;
+  color: #a6e3a1;
 }
 
 .disconnect-btn {
   background: none;
-  border: 1px solid #374151;
-  color: #9ca3af;
+  border: 1px solid #45475a;
+  color: #a6adc8;
   font-family: inherit;
-  font-size: 0.7rem;
-  padding: 0.3rem 0.75rem;
+  font-size: 0.75rem;
+  font-weight: 500;
+  padding: 0.35rem 0.85rem;
   cursor: pointer;
-  border-radius: 3px;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  transition: color 0.15s, border-color 0.15s;
+  border-radius: 6px;
+  transition: color 0.15s, border-color 0.15s, background-color 0.15s;
 }
 
 .disconnect-btn:hover {
-  color: #ef4444;
-  border-color: #ef4444;
+  color: #f38ba8;
+  border-color: rgba(243, 139, 168, 0.4);
+  background-color: rgba(243, 139, 168, 0.08);
 }
 
 /* ── Footer ────────────────────────────────── */
 
+/* Footer alignment is theme-driven: Modern → right-aligned, Classic →
+ * left-aligned. The footer fills the .terminal-block's width (which
+ * equals the terminal-wrapper's scaled width), so the justify-content
+ * anchors items to the terminal's left/right edges. */
 .demo-footer {
   display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 1.5rem;
-  margin-top: 1.5rem;
+  flex-direction: column;
+  align-items: flex-end; /* keeps the stack anchored to the terminal's right edge */
+  justify-content: space-between;
+  gap: 0.5rem;
   font-size: 0.8rem;
 }
 
+
+/* Shared height for install-cmd pill + GitHub button so they visually
+ * align. 38px is set explicitly; internal flex centering handles the
+ * content regardless of per-element padding. */
+.install-cmd-wrap,
+.github-btn {
+  height: 34px;
+  box-sizing: border-box;
+}
+
+.install-cmd-wrap {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  background: #181825;
+  border: 1px solid #313244;
+  border-radius: 6px;
+  padding: 0 0.6rem 0 0.85rem;
+}
+
 .install-cmd {
-  background: #161616;
-  color: #33ff33;
-  padding: 0.4rem 0.75rem;
+  color: #cba6f7;
+  font-family: 'JetBrains Mono', 'Courier New', monospace;
+  font-size: 0.85rem;
+  line-height: 1;
+}
+
+.copy-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  background: transparent;
+  border: 1px solid transparent;
   border-radius: 4px;
-  border: 1px solid #2a2a2a;
+  color: #6c7086;
+  cursor: pointer;
+  transition: color 0.12s, background 0.12s, border-color 0.12s;
+  padding: 0;
 }
 
-.github-link {
-  color: #6b7280;
+.copy-btn:hover {
+  color: #cdd6f4;
+  background: rgba(205, 214, 244, 0.06);
+  border-color: #313244;
+}
+
+.copy-btn.copied {
+  color: #a6e3a1;
+  border-color: rgba(166, 227, 161, 0.4);
+  background: rgba(166, 227, 161, 0.08);
+}
+
+/* ── GitHub button ─────────────────────────── */
+
+.github-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  /* No vertical padding: the shared 38px `height` + `align-items: center`
+   * handles vertical centering. Matches install-cmd-wrap's padding model
+   * so both boxes look identical in weight across both themes. */
+  padding: 0 0.85rem;
+  background: #24292f;
+  color: #f0f6fc;
+  border: 1px solid #444c56;
+  border-radius: 6px;
   text-decoration: none;
-  transition: color 0.15s;
+  font-weight: 600;
+  font-size: 0.85rem;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+  line-height: 1;
+  transition: background 0.15s, border-color 0.15s;
 }
 
-.github-link:hover {
-  color: #e2e8f0;
+.github-btn:hover {
+  background: #30363d;
+  border-color: #6e7681;
+}
+
+.github-btn svg {
+  flex-shrink: 0;
+}
+
+/* ── Theme toggle (2-state pill switch) ─────── */
+
+/* Inset shadow on the track gives the pill visible depth, as if the
+ * active option is sunk into a groove. The active pill adds a small
+ * raised shadow plus a subtle scale-on-hover for tactile feedback. */
+/* Theme-toggle row: full-width flex container that holds .theme-picker.
+ * Uses flex-grow on ::before/::after pseudo-elements to push the picker to
+ * one side: Classic → left, Modern → right. flex-grow IS animatable, so
+ * the picker slides smoothly between the two sides when the user swaps
+ * themes. Also adds vertical headroom so the picker clears the theme
+ * sticker (sticker is on the OPPOSITE side in each theme, so horizontal
+ * overlap is impossible; this just handles any residual vertical
+ * co-occupancy). */
+.terminal-block-theme-row {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  margin-top: 1rem;
+}
+.terminal-block-theme-row::before,
+.terminal-block-theme-row::after {
+  content: '';
+  flex-grow: 0;
+  transition: flex-grow 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+}
+/* Modern: ::before grows, picker pushed to the RIGHT edge of the row. */
+body.gs-demo-theme-modern .terminal-block-theme-row::before { flex-grow: 1; }
+body.gs-demo-theme-modern .terminal-block-theme-row::after  { flex-grow: 0; }
+/* Classic: ::after grows, picker pushed to the LEFT edge of the row. */
+body.gs-demo-theme-classic .terminal-block-theme-row::before { flex-grow: 0; }
+body.gs-demo-theme-classic .terminal-block-theme-row::after  { flex-grow: 1; }
+
+.theme-picker {
+  display: inline-flex;
+  margin: 0 0 1.25rem;
+  padding: 3px;
+  background: #181825;
+  border: 1px solid #313244;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  box-shadow:
+    inset 0 1px 2px rgba(0, 0, 0, 0.45),
+    inset 0 -1px 0 rgba(255, 255, 255, 0.02);
+  transition: background 0.3s ease, border-color 0.3s ease,
+              box-shadow 0.3s ease;
+}
+
+.theme-toggle-option {
+  background: transparent;
+  color: #6c7086;
+  border: none;
+  border-radius: 999px;
+  padding: 0.4rem 0.9rem;
+  font-family: inherit;
+  font-size: inherit;
+  font-weight: 500;
+  cursor: pointer;
+  outline: none;
+  white-space: nowrap;
+  /* Smooth cross-fade + slide-in effect when toggling. */
+  transition: background 0.28s cubic-bezier(0.4, 0, 0.2, 1),
+              color 0.28s cubic-bezier(0.4, 0, 0.2, 1),
+              box-shadow 0.28s cubic-bezier(0.4, 0, 0.2, 1),
+              transform 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.theme-toggle-option:hover:not(.active) {
+  color: #cdd6f4;
+  background: rgba(205, 214, 244, 0.04);
+}
+
+.theme-toggle-option.active {
+  background: #cba6f7;
+  color: #11111b;
+  box-shadow:
+    0 2px 6px rgba(203, 166, 247, 0.35),
+    0 1px 2px rgba(0, 0, 0, 0.25),
+    inset 0 1px 0 rgba(255, 255, 255, 0.35);
+}
+
+/* Classic theme: remove all rounded corners on demo chrome (theme
+ * sticker, copy button, github button, terminal wrapper, etc.) to match
+ * the blocky CRT aesthetic of the terminal itself. */
+body.gs-demo-theme-classic .terminal-wrapper,
+body.gs-demo-theme-classic .install-cmd-wrap,
+body.gs-demo-theme-classic .copy-btn,
+body.gs-demo-theme-classic .github-btn,
+body.gs-demo-theme-classic .theme-sticker,
+body.gs-demo-theme-classic .connect-error,
+body.gs-demo-theme-classic .connect-note {
+  border-radius: 0;
+}
+
+/* Classic: the active pill flips to phosphor green on the black track. */
+body.gs-demo-theme-classic .theme-picker {
+  background: #0a0a0a;
+  border-color: #1a1a1a;
+}
+body.gs-demo-theme-classic .theme-toggle-option.active {
+  background: #29fa29;
+  color: #000000;
+}
+body.gs-demo-theme-classic .theme-toggle-option {
+  border-radius: 0;
+}
+body.gs-demo-theme-classic .theme-picker {
+  border-radius: 0;
+}
+
+/* ── "Powered by LegacyBridge" attribution ───────────── */
+
+.powered-by {
+  margin-top: 2.5rem;
+  padding: 1rem 0 0.5rem;
+  text-align: center;
+  color: #6c7086;
+  font-size: 0.8rem;
+  border-top: 1px solid #1f1f2e;
+  transition: border-color 0.3s ease, color 0.3s ease;
+}
+
+body.gs-demo-theme-classic .powered-by {
+  border-top-color: #1a1a1a;
+  color: #8a8a8a;
+}
+
+.powered-by-line {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+}
+
+.powered-by-label {
+  opacity: 0.75;
+}
+
+.legacybridge-logo {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  /* Icon color — teal-green matching the chip outline in the mark. */
+  color: #3fba7a;
+  font-weight: 700;
+  text-decoration: none;
+  transition: opacity 0.15s;
+}
+
+.legacybridge-logo:hover {
+  opacity: 0.85;
+}
+
+.legacybridge-wordmark {
+  display: inline-flex;
+  letter-spacing: -0.01em;
+  font-size: 0.95rem;
+}
+
+.lb-legacy { color: #3fba7a; }
+.lb-bridge { color: #cdd6f4; }
+
+/* Classic theme: whole mark flips to phosphor green to match the CRT
+ * aesthetic of the rest of the page. */
+body.gs-demo-theme-classic .legacybridge-logo,
+body.gs-demo-theme-classic .lb-legacy,
+body.gs-demo-theme-classic .lb-bridge {
+  color: #29fa29;
+}
+
+.powered-by-tagline {
+  margin-top: 0.35rem;
+  font-size: 0.78rem;
+  opacity: 0.75;
+  font-style: italic;
 }
 
 /* ── Standalone mode ─────────────────────── */
 
 body.standalone {
-  background: #000000;
+  background: #11111b;
   overflow: hidden;
 }
 
@@ -285,7 +887,7 @@ body.standalone {
   display: flex;
   align-items: center;
   justify-content: center;
-  background: #000000;
+  background: #11111b;
 }
 
 .standalone-page .terminal-wrapper {

--- a/apps/demo/src/App.tsx
+++ b/apps/demo/src/App.tsx
@@ -1,6 +1,16 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, createContext, useContext } from 'react'
 import { GreenScreenTerminal, WebSocketAdapter } from 'green-screen-react'
 import type { TerminalAdapter, ConnectConfig } from 'green-screen-react'
+
+// --- Theme context (demo-app only) ---
+// The theme picker lives outside the terminal and drives the `theme` prop
+// passed to <GreenScreenTerminal>. This demonstrates how an integrator can
+// swap visual presets at runtime without remounting the terminal.
+type DemoTheme = 'modern' | 'classic'
+const ThemeContext = createContext<{ theme: DemoTheme; setTheme: (t: DemoTheme) => void }>({
+  theme: 'modern',
+  setTheme: () => {},
+})
 
 // Default Worker URL — update this after deploying the Cloudflare Worker
 const DEFAULT_WORKER_URL = import.meta.env.VITE_WORKER_URL || ''
@@ -31,7 +41,7 @@ function ConnectPanel({ standalone = false }: { standalone?: boolean }) {
   const [connected, setConnected] = useState(false)
   const [adapter, setAdapter] = useState<TerminalAdapter | null>(null)
   const [error, setError] = useState<string | null>(null)
-  const [connectedHost, setConnectedHost] = useState('')
+  const [connectedConfig, setConnectedConfig] = useState<ConnectConfig | null>(null)
   const [restoring, setRestoring] = useState(true)
 
   const doConnect = async (config: ConnectConfig) => {
@@ -41,7 +51,7 @@ function ConnectPanel({ standalone = false }: { standalone?: boolean }) {
     if (result.success) {
       setAdapter(wsAdapter)
       setConnected(true)
-      setConnectedHost(config.host)
+      setConnectedConfig(config)
       saveSession(config, wsAdapter.sessionId!)
     } else {
       wsAdapter.dispose()
@@ -64,7 +74,7 @@ function ConnectPanel({ standalone = false }: { standalone?: boolean }) {
       if (result.success) {
         setAdapter(wsAdapter)
         setConnected(true)
-        setConnectedHost(saved.config.host)
+        setConnectedConfig(saved.config)
         // Update sessionId in case it changed
         saveSession(saved.config, wsAdapter.sessionId!)
         return
@@ -102,17 +112,13 @@ function ConnectPanel({ standalone = false }: { standalone?: boolean }) {
     }
   }
 
-  const handleDisconnect = async () => {
-    // Await the adapter's disconnect so the UI only transitions to
-    // "disconnected" after the server has acked the SIGNOFF round-trip.
-    // Otherwise we'd race the server teardown and leak a half-open 5250
-    // session on the host (IBM i + LMTDEVSSN=*YES → CPF1220 on next login).
-    if (adapter && 'disconnect' in adapter) {
-      try { await (adapter as WebSocketAdapter).disconnect() } catch { /* ignore */ }
-    }
+  // Called by the terminal component after its built-in Disconnect button
+  // tears down the adapter. Clears demo-side state (adapter ref, session
+  // storage, connected flag) so we don't leak a stale reference.
+  const handleDisconnect = () => {
     setAdapter(null)
     setConnected(false)
-    setConnectedHost('')
+    setConnectedConfig(null)
     clearSession()
   }
 
@@ -140,40 +146,51 @@ function ConnectPanel({ standalone = false }: { standalone?: boolean }) {
   if (restoring) {
     return (
       <div className={standalone ? 'standalone-page' : 'connect-panel'} style={{ textAlign: 'center', padding: standalone ? undefined : '3rem' }}>
-        <p style={{ color: '#808080', fontFamily: 'var(--gs-font, monospace)', fontSize: '13px' }}>Reconnecting...</p>
+        <p style={{ color: '#6c7086', fontFamily: 'var(--gs-font, monospace)', fontSize: '13px' }}>Reconnecting...</p>
       </div>
     )
   }
 
   if (connected && adapter) {
+    // Pass host + username via connectionStatus so they appear in the
+    // terminal's built-in header. The terminal's own Disconnect button
+    // tears down the adapter; onDisconnect clears demo-side state.
+    const connectionStatus = {
+      connected: true,
+      status: 'authenticated' as const,
+      host: connectedConfig?.host,
+      username: connectedConfig?.username,
+    }
     if (standalone) {
       return (
         <div className="standalone-page">
           <div className="terminal-wrapper">
-            <GreenScreenTerminal
+            <ThemeSticker />
+            <ThemedTerminal
               adapter={adapter}
               protocol="tn5250"
               inlineSignIn={false}
               pollInterval={500}
+              connectionStatus={connectionStatus}
+              onDisconnect={handleDisconnect}
+              alwaysFocused
             />
           </div>
         </div>
       )
     }
     return (
-      <div>
-        <div style={{ marginBottom: '0.75rem', display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-          <span className="connect-status connected">Connected to {connectedHost}</span>
-          <button className="disconnect-btn" onClick={handleDisconnect}>Disconnect</button>
-        </div>
-        <div className="terminal-wrapper">
-          <GreenScreenTerminal
-            adapter={adapter}
-            protocol="tn5250"
-            inlineSignIn={false}
-            pollInterval={500}
-          />
-        </div>
+      <div className="terminal-wrapper">
+        <ThemeSticker />
+        <ThemedTerminal
+          adapter={adapter}
+          protocol="tn5250"
+          inlineSignIn={false}
+          pollInterval={500}
+          connectionStatus={connectionStatus}
+          onDisconnect={handleDisconnect}
+          alwaysFocused
+        />
       </div>
     )
   }
@@ -182,7 +199,7 @@ function ConnectPanel({ standalone = false }: { standalone?: boolean }) {
     return (
       <div className="standalone-page">
         <div className="terminal-wrapper">
-          <GreenScreenTerminal
+          <ThemedTerminal
             protocol="tn5250"
             inlineSignIn={true}
             defaultProtocol="tn5250"
@@ -198,26 +215,43 @@ function ConnectPanel({ standalone = false }: { standalone?: boolean }) {
     )
   }
 
+  // Not-connected: render info + form as Fragment children directly (no
+  // surrounding .connect-panel wrapper). The parent .terminal-block flex
+  // column sizes to the widest child (the terminal-wrapper), and the info
+  // block is capped in width via CSS so it doesn't stretch the block out.
   return (
-    <div className="connect-panel">
+    <>
       <div className="connect-info">
-        <h3>Connect to your system</h3>
-        <p>
-          Enter your host details to connect directly from this page.
-          The connection is proxied through the local proxy server or a Cloudflare Worker.
-        </p>
-        <div className="connect-note">
-          Credentials are sent directly to the target host. Your password is never stored;
-          other connection details (host, port, protocol, username) are saved in this
-          browser&rsquo;s local storage for convenience.
-        </div>
+        <h3 className="connect-heading">
+          Connect to your system
+          <button
+            type="button"
+            className="info-tooltip-btn"
+            aria-label="More info about connection"
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              <circle cx="12" cy="12" r="10" />
+              <line x1="12" y1="16" x2="12" y2="12" />
+              <line x1="12" y1="8" x2="12.01" y2="8" />
+            </svg>
+            <span className="info-tooltip">
+              Enter your host details to connect directly from this page.
+              The connection is proxied through the local proxy server or a Cloudflare Worker.
+              <br /><br />
+              Credentials are sent directly to the target host. Your password is never stored;
+              other connection details (host, port, protocol, username) are saved in this
+              browser&rsquo;s local storage for convenience.
+            </span>
+          </button>
+        </h3>
       </div>
 
       <div className="connect-form">
         {error && <div className="connect-error">{error}</div>}
 
         <div className="terminal-wrapper" style={{ minHeight: 'auto' }}>
-          <GreenScreenTerminal
+          <ThemeSticker />
+          <ThemedTerminal
             protocol="tn5250"
             inlineSignIn={true}
             defaultProtocol="tn5250"
@@ -230,7 +264,7 @@ function ConnectPanel({ standalone = false }: { standalone?: boolean }) {
           />
         </div>
       </div>
-    </div>
+    </>
   )
 }
 
@@ -250,25 +284,232 @@ export default function App() {
   }
 
   return (
-    <div className="demo-page">
-      <header className="demo-header">
-        <h1 className="demo-title">green-screen-react</h1>
-        <p className="demo-subtitle">Multi-protocol legacy terminal emulator for React</p>
-      </header>
+    <DemoThemeProvider>
+      <div className="demo-page">
+        {/* Terminal block: the header (title + subtitle), npx + GitHub,
+         * terminal, and theme toggle all live inside a single flex column
+         * that hugs the terminal's fit-to-content width. This aligns the
+         * page title to the terminal's LEFT edge (instead of centering it
+         * against the 920px page column). */}
+        <div className="terminal-block">
+          <header className="demo-header">
+            <div className="demo-header-row">
+              <div className="demo-header-text">
+                <h1 className="demo-title">
+                  @green-screen-react
+                  <span className="demo-title-badge">DEMO / PREVIEW</span>
+                </h1>
+                <p className="demo-subtitle">Multi-protocol legacy terminal emulator for React</p>
+              </div>
+              <div className="demo-footer">
+                <GitHubButton />
+                <CopyInstallCmd />
+              </div>
+            </div>
+          </header>
+          <ConnectPanel />
+          <div className="terminal-block-theme-row">
+            <ThemePicker />
+          </div>
+        </div>
 
-      <ConnectPanel />
+        <PoweredByLegacyBridge />
+      </div>
+    </DemoThemeProvider>
+  )
+}
 
-      <footer className="demo-footer">
-        <code className="install-cmd">npx green-screen-terminal</code>
+/** Attribution block pinned near the bottom of the page. Links to the
+ * LegacyBridge landing page and adds a one-line tagline. The wordmark is
+ * rendered as styled text with an inline logo glyph — no external asset
+ * dependency. */
+function PoweredByLegacyBridge() {
+  return (
+    <div className="powered-by">
+      <div className="powered-by-line">
+        <span className="powered-by-label">Powered by</span>
         <a
-          href="https://github.com/visionbridge-solutions/green-screen-react"
-          className="github-link"
+          href="https://legacybridge.software"
           target="_blank"
           rel="noopener noreferrer"
+          className="legacybridge-logo"
+          aria-label="LegacyBridge"
         >
-          GitHub &rarr;
+          <svg width="22" height="22" viewBox="0 0 32 32" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+            {/* Processor-chip pins (3 per edge) */}
+            <line x1="10" y1="1.5" x2="10" y2="5.5" />
+            <line x1="16" y1="1.5" x2="16" y2="5.5" />
+            <line x1="22" y1="1.5" x2="22" y2="5.5" />
+            <line x1="10" y1="26.5" x2="10" y2="30.5" />
+            <line x1="16" y1="26.5" x2="16" y2="30.5" />
+            <line x1="22" y1="26.5" x2="22" y2="30.5" />
+            <line x1="1.5" y1="10" x2="5.5" y2="10" />
+            <line x1="1.5" y1="16" x2="5.5" y2="16" />
+            <line x1="1.5" y1="22" x2="5.5" y2="22" />
+            <line x1="26.5" y1="10" x2="30.5" y2="10" />
+            <line x1="26.5" y1="16" x2="30.5" y2="16" />
+            <line x1="26.5" y1="22" x2="30.5" y2="22" />
+            {/* Chip body */}
+            <rect x="5.5" y="5.5" width="21" height="21" rx="3.5" />
+            {/* Interior staircase / circuit path */}
+            <path d="M11 21.5 H14.5 V17.5 H18 V13.5 H21.5" />
+          </svg>
+          <span className="legacybridge-wordmark">
+            <span className="lb-legacy">Legacy</span><span className="lb-bridge">Bridge</span>
+          </span>
         </a>
-      </footer>
+      </div>
+      <div className="powered-by-tagline">
+        We teach AI to use 5250 terminals safely
+      </div>
     </div>
+  )
+}
+
+/** Wrapper that reads the demo theme from context and forwards it to
+ * <GreenScreenTerminal>. Lets us swap themes at runtime without having to
+ * thread the prop through every callsite. */
+function ThemedTerminal(props: React.ComponentProps<typeof GreenScreenTerminal>) {
+  const { theme } = useContext(ThemeContext)
+  return <GreenScreenTerminal {...props} theme={theme} />
+}
+
+/** Theme-dependent sticker positioned BELOW the terminal.
+ *   Classic: paper sticky-note (right side, taped on, slight rotation).
+ *   Modern:  brushed-metal panel (left side, flat, four corner screws).
+ * Wraps inside `.terminal-wrapper` (position: relative). */
+function ThemeSticker() {
+  const { theme } = useContext(ThemeContext)
+  const [line1, line2] = theme === 'classic'
+    ? ['Phosphor included', "The classic 1978's recipe"]
+    : ['Phosphor-free', 'Still eco-friendly']
+  return (
+    <div className={`theme-sticker theme-sticker-${theme}`} aria-hidden="true">
+      {theme === 'modern' && (
+        <>
+          {/* Only top screws — visually lighter, more like a nameplate
+           * hung by its top edge rather than fully fastened. */}
+          <span className="sticker-screw sticker-screw-tl" />
+          <span className="sticker-screw sticker-screw-tr" />
+        </>
+      )}
+      <span className="theme-sticker-line1">{line1}</span>
+      <span className="theme-sticker-line2">{line2}</span>
+    </div>
+  )
+}
+
+/** Demo-only: provides a DemoTheme and a setter. */
+function DemoThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setTheme] = useState<DemoTheme>(() => {
+    try { return (localStorage.getItem('gs-demo-theme') as DemoTheme) || 'modern' } catch { return 'modern' }
+  })
+  useEffect(() => {
+    try { localStorage.setItem('gs-demo-theme', theme) } catch {}
+    // Reflect theme on <body> so the page background and the <html>
+    // scroll-area can restyle to match the terminal palette.
+    document.body.classList.toggle('gs-demo-theme-modern', theme === 'modern')
+    document.body.classList.toggle('gs-demo-theme-classic', theme === 'classic')
+  }, [theme])
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  )
+}
+
+function ThemePicker() {
+  const { theme, setTheme } = useContext(ThemeContext)
+  return (
+    <div className="theme-picker" role="radiogroup" aria-label="Theme">
+      <button
+        type="button"
+        role="radio"
+        aria-checked={theme === 'classic'}
+        className={`theme-toggle-option${theme === 'classic' ? ' active' : ''}`}
+        onClick={() => setTheme('classic')}
+      >
+        Classic (Phosphor)
+      </button>
+      <button
+        type="button"
+        role="radio"
+        aria-checked={theme === 'modern'}
+        className={`theme-toggle-option${theme === 'modern' ? ' active' : ''}`}
+        onClick={() => setTheme('modern')}
+      >
+        Modern (Aurora)
+      </button>
+    </div>
+  )
+}
+
+/** Copy button that transforms to a green checkmark for 2 seconds after click. */
+function CopyInstallCmd() {
+  const CMD = 'npx green-screen-terminal'
+  const [copied, setCopied] = useState(false)
+  const handleCopy = async () => {
+    // Try the modern async API first; fall back to execCommand for
+    // environments where clipboard access is blocked (iframes, insecure
+    // contexts). Visual feedback fires either way so the user sees the
+    // intent even if the copy itself silently failed.
+    let ok = false
+    try {
+      await navigator.clipboard.writeText(CMD)
+      ok = true
+    } catch {
+      try {
+        const ta = document.createElement('textarea')
+        ta.value = CMD
+        ta.style.cssText = 'position:fixed;left:-9999px;top:0;opacity:0'
+        document.body.appendChild(ta)
+        ta.focus(); ta.select()
+        ok = document.execCommand('copy')
+        document.body.removeChild(ta)
+      } catch { /* give up */ }
+    }
+    if (ok || !ok /* show feedback regardless */) {
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    }
+  }
+  return (
+    <div className="install-cmd-wrap">
+      <code className="install-cmd">{CMD}</code>
+      <button
+        type="button"
+        className={`copy-btn${copied ? ' copied' : ''}`}
+        onClick={handleCopy}
+        aria-label={copied ? 'Copied!' : 'Copy install command'}
+        title={copied ? 'Copied!' : 'Copy'}
+      >
+        {copied ? (
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round">
+            <polyline points="20 6 9 17 4 12" />
+          </svg>
+        ) : (
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+            <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+          </svg>
+        )}
+      </button>
+    </div>
+  )
+}
+
+function GitHubButton() {
+  return (
+    <a
+      href="https://github.com/visionbridge-solutions/green-screen-react"
+      className="github-btn"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+        <path d="M12 0C5.37 0 0 5.37 0 12c0 5.3 3.44 9.8 8.2 11.39.6.1.82-.26.82-.58 0-.29-.01-1.04-.02-2.05-3.34.72-4.04-1.61-4.04-1.61-.55-1.39-1.33-1.76-1.33-1.76-1.09-.75.08-.73.08-.73 1.2.08 1.83 1.23 1.83 1.23 1.07 1.83 2.8 1.3 3.49.99.11-.78.42-1.3.76-1.6-2.67-.3-5.47-1.34-5.47-5.95 0-1.32.47-2.4 1.24-3.24-.13-.3-.54-1.53.11-3.19 0 0 1-.32 3.3 1.23a11.5 11.5 0 0 1 6 0c2.3-1.55 3.3-1.23 3.3-1.23.65 1.66.24 2.89.12 3.19.77.84 1.23 1.92 1.23 3.24 0 4.62-2.81 5.64-5.49 5.94.43.37.81 1.1.81 2.22 0 1.6-.02 2.9-.02 3.29 0 .32.22.69.83.57C20.57 21.8 24 17.3 24 12 24 5.37 18.63 0 12 0z"/>
+      </svg>
+      <span>GitHub</span>
+    </a>
   )
 }

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "green-screen-proxy",
-  "version": "1.2.6",
+  "version": "1.3.0",
   "description": "WebSocket/REST proxy server for green-screen-react — connects browsers to TN5250, TN3270, VT220, and HP 6530 hosts over TCP",
   "type": "module",
   "bin": {

--- a/packages/proxy/src/protocols/tn5250-handler.ts
+++ b/packages/proxy/src/protocols/tn5250-handler.ts
@@ -66,6 +66,16 @@ export class TN5250Handler extends ProtocolHandler {
       registerBuiltinDbcsTable();
     }
 
+    // Pass environment variables for NEW_ENVIRON negotiation.
+    // DEVNAME is the IBM i display device name (per lib5250 telnetstr.c:632-664).
+    const envVars: Record<string, string> = {};
+    if (options?.deviceName && typeof options.deviceName === 'string') {
+      envVars['DEVNAME'] = options.deviceName;
+    }
+    if (Object.keys(envVars).length > 0) {
+      this.connection.setEnvVars(envVars);
+    }
+
     const connectTimeout = options?.connectTimeout as number | undefined;
     await this.connection.connect(host, port, termType, connectTimeout);
   }

--- a/packages/proxy/src/tn5250/connection.ts
+++ b/packages/proxy/src/tn5250/connection.ts
@@ -21,6 +21,8 @@ export class TN5250Connection extends EventEmitter {
   private recvBuffer: Buffer = Buffer.alloc(0);
   private negotiationDone: boolean = false;
   private terminalType: string = DEFAULT_TERMINAL_TYPE;
+  /** Environment variables to send in NEW_ENVIRON (e.g., DEVNAME for device name). */
+  private envVars: Record<string, string> = {};
   private keepAliveTimer: ReturnType<typeof setInterval> | null = null;
   private static readonly KEEP_ALIVE_INTERVAL = 15_000; // 15s — well under PUB400's ~30s idle timeout
   // Timing Mark (IAC DO TM) instead of NOP — it's a round-trip: the server
@@ -39,6 +41,15 @@ export class TN5250Connection extends EventEmitter {
 
   get remotePort(): number {
     return this.port;
+  }
+
+  /**
+   * Set environment variables to send during NEW_ENVIRON negotiation.
+   * Per lib5250 telnetstr.c:632-664, these are sent as VAR name VALUE value
+   * pairs. Common vars: DEVNAME (device name), TERM, IBMMFRTYPMDL.
+   */
+  setEnvVars(vars: Record<string, string>): void {
+    this.envVars = { ...vars };
   }
 
   connect(host: string, port: number, terminalType?: string, connectTimeout?: number): Promise<void> {
@@ -201,11 +212,17 @@ export class TN5250Connection extends EventEmitter {
     }
   }
 
-  /** Find IAC SE sequence for subnegotiation end */
+  /** Find IAC SE sequence for subnegotiation end, skipping IAC IAC escapes */
   private findSubnegEnd(): number {
     for (let i = 2; i < this.recvBuffer.length - 1; i++) {
-      if (this.recvBuffer[i] === TELNET.IAC && this.recvBuffer[i + 1] === TELNET.SE) {
-        return i;
+      if (this.recvBuffer[i] === TELNET.IAC) {
+        if (this.recvBuffer[i + 1] === TELNET.SE) {
+          return i;
+        }
+        if (this.recvBuffer[i + 1] === TELNET.IAC) {
+          i++; // skip escaped IAC IAC pair
+          continue;
+        }
       }
     }
     return -1;
@@ -311,13 +328,22 @@ export class TN5250Connection extends EventEmitter {
   }
 
   private sendEnviron(data: Buffer): void {
-    // Send empty NEW-ENVIRON response
-    const buf = Buffer.from([
-      TELNET.IAC, TELNET.SB, TELNET.OPT_NEW_ENVIRON,
-      0x00, // IS
-      TELNET.IAC, TELNET.SE,
-    ]);
-    this.sendRaw(buf);
+    // Per lib5250 telnetstr.c:632-664: send NEW_ENVIRON IS with all env vars.
+    // Each var is encoded as: VAR(0x00) name VALUE(0x01) value
+    // USERVAR(0x03) can also be used for user-defined vars.
+    const parts: number[] = [TELNET.IAC, TELNET.SB, TELNET.OPT_NEW_ENVIRON, 0x00 /* IS */];
+
+    for (const [name, value] of Object.entries(this.envVars)) {
+      // Use USERVAR (0x03) for custom vars like DEVNAME, VAR (0x00) for standard ones
+      const varType = (name === 'TERM' || name === 'USER') ? 0x00 : 0x03;
+      parts.push(varType);
+      for (let i = 0; i < name.length; i++) parts.push(name.charCodeAt(i));
+      parts.push(0x01); // VALUE
+      for (let i = 0; i < value.length; i++) parts.push(value.charCodeAt(i));
+    }
+
+    parts.push(TELNET.IAC, TELNET.SE);
+    this.sendRaw(Buffer.from(parts));
   }
 
   private handleTN5250ESubneg(_data: Buffer): void {

--- a/packages/proxy/src/tn5250/constants.ts
+++ b/packages/proxy/src/tn5250/constants.ts
@@ -66,8 +66,16 @@ export const CMD = {
   READ_IMMEDIATE_ALT: 0x83,
   WRITE_STRUCTURED_FIELD: 0xF3,
   SAVE_SCREEN: 0x02,
+  SAVE_PARTIAL_SCREEN: 0x03,
   RESTORE_SCREEN: 0x12,
+  RESTORE_PARTIAL_SCREEN: 0x13,
   ROLL: 0x23,
+  // Read commands ignored in C library but recognized for dispatch
+  READ_SCREEN_EXTENDED: 0x64,
+  READ_SCREEN_PRINT: 0x66,
+  READ_SCREEN_PRINT_EXTENDED: 0x68,
+  READ_SCREEN_PRINT_GRID: 0x6A,
+  READ_SCREEN_PRINT_EXT_GRID: 0x6C,
 } as const;
 
 // Record header flag byte values (byte 8 of the GDS header).

--- a/packages/proxy/src/tn5250/encoder.ts
+++ b/packages/proxy/src/tn5250/encoder.ts
@@ -78,6 +78,19 @@ export class TN5250Encoder {
       );
     }
 
+    // Per lib5250 dbuffer.c:193-318: check the SOH header key mask to see
+    // if field data should be sent for this AID key. If the mask says no,
+    // send cursor+AID only (like CLEAR).
+    if (!this.shouldSendDataForAid(aidByte)) {
+      this.screen.readOpcode = 0;
+      this.screen.keyboardLocked = true;
+      return this.buildPacket(
+        RECORD_H.NONE,
+        RECORD_OPCODE.PUT_GET,
+        Buffer.concat(parts),
+      );
+    }
+
     // Dispatch by read_opcode — each mode has different encoding rules for
     // modified flag selection, NUL handling, and sign-nibble handling.
     // If no read_opcode is set (host never issued a Read), fall back to
@@ -251,6 +264,44 @@ export class TN5250Encoder {
     }
 
     return Buffer.concat(pieces);
+  }
+
+  /** Encode one single field's content to EBCDIC (no continuation walk). */
+  /**
+   * Check the SOH header key mask to determine if field data should be
+   * sent for the given AID key. Per lib5250 dbuffer.c:193-318.
+   *
+   * The key mask is stored in SOH header bytes 4-6 (0-indexed).
+   * Uses `header_data[byte] & (0x80 >> bit)` where bit descends from 7
+   * for the first key in each group. If the masked bit is CLEAR (0),
+   * data SHOULD be sent (result=1); if SET (1), data should NOT be sent.
+   * For non-function-key AIDs (Enter, PageUp, etc.) data is always sent.
+   */
+  private shouldSendDataForAid(aidByte: number): boolean {
+    const hdr = this.screen.headerData;
+    // No key mask if header is too short (< 7 bytes)
+    if (!hdr || hdr.length <= 6) return true;
+
+    // Map F-key AID bytes to (byteIndex, bit) matching lib5250 exactly.
+    // The C code uses: result = ((header_data[byte] & (0x80 >> bit)) == 0)
+    // F1-F8: byte 6, bits 7..0
+    // F9-F16: byte 5, bits 7..0
+    // F17-F24: byte 4, bits 7..0
+    const aidKeyMap: Record<number, [number, number]> = {
+      [AID.F1]: [6, 7],  [AID.F2]: [6, 6],  [AID.F3]: [6, 5],  [AID.F4]: [6, 4],
+      [AID.F5]: [6, 3],  [AID.F6]: [6, 2],  [AID.F7]: [6, 1],  [AID.F8]: [6, 0],
+      [AID.F9]: [5, 7],  [AID.F10]: [5, 6], [AID.F11]: [5, 5], [AID.F12]: [5, 4],
+      [AID.F13]: [5, 3], [AID.F14]: [5, 2], [AID.F15]: [5, 1], [AID.F16]: [5, 0],
+      [AID.F17]: [4, 7], [AID.F18]: [4, 6], [AID.F19]: [4, 5], [AID.F20]: [4, 4],
+      [AID.F21]: [4, 3], [AID.F22]: [4, 2], [AID.F23]: [4, 1], [AID.F24]: [4, 0],
+    };
+
+    const mapping = aidKeyMap[aidByte];
+    if (!mapping) return true; // Non-F-key AIDs always send data
+
+    const [byteIdx, bit] = mapping;
+    // Per lib5250: bit CLEAR = send data; bit SET = don't send
+    return (hdr[byteIdx] & (0x80 >> bit)) === 0;
   }
 
   /** Encode one single field's content to EBCDIC (no continuation walk). */

--- a/packages/proxy/src/tn5250/parser.ts
+++ b/packages/proxy/src/tn5250/parser.ts
@@ -19,6 +19,9 @@ export class TN5250Parser {
    *  relative to the window content area, not the full screen. */
   winRowOff = 0;
   winColOff = 0;
+  /** Set during parseRecord when opcode is RESTORE_SCREEN; used by
+   *  parseOrders for post-WTD cursor positioning per lib5250. */
+  private isRestoreScreen = false;
 
   constructor(screen: ScreenBuffer) {
     this.screen = screen;
@@ -30,6 +33,7 @@ export class TN5250Parser {
    */
   parseRecord(record: Buffer): boolean {
     this.icApplied = false;
+    this.isRestoreScreen = false;
     if (record.length < 2) return false;
 
     // 5250 record header:
@@ -97,6 +101,7 @@ export class TN5250Parser {
         break;
 
       case OPCODE.RESTORE_SCREEN:
+        this.isRestoreScreen = true;
         this.screen.restoreState();
         this.screen.windowList = [];
         this.winRowOff = 0;
@@ -125,12 +130,41 @@ export class TN5250Parser {
     return this.parseCommandsFromOffset(record, 0);
   }
 
+  /** Check if a byte is a known 5250 command code. */
+  private static isKnownCommand(b: number): boolean {
+    return (
+      b === CMD.WRITE_TO_DISPLAY ||
+      b === CMD.CLEAR_UNIT ||
+      b === CMD.CLEAR_UNIT_ALT ||
+      b === CMD.CLEAR_FORMAT_TABLE ||
+      b === CMD.WRITE_STRUCTURED_FIELD ||
+      b === CMD.WRITE_ERROR_CODE ||
+      b === CMD.WRITE_ERROR_CODE_WIN ||
+      b === CMD.READ_INPUT_FIELDS ||
+      b === CMD.READ_MDT_FIELDS ||
+      b === CMD.READ_MDT_FIELDS_ALT ||
+      b === CMD.READ_SCREEN_IMMEDIATE ||
+      b === CMD.READ_IMMEDIATE ||
+      b === CMD.READ_IMMEDIATE_ALT ||
+      b === CMD.SAVE_SCREEN ||
+      b === CMD.SAVE_PARTIAL_SCREEN ||
+      b === CMD.RESTORE_SCREEN ||
+      b === CMD.RESTORE_PARTIAL_SCREEN ||
+      b === CMD.ROLL ||
+      b === CMD.READ_SCREEN_EXTENDED ||
+      b === CMD.READ_SCREEN_PRINT ||
+      b === CMD.READ_SCREEN_PRINT_EXTENDED ||
+      b === CMD.READ_SCREEN_PRINT_GRID ||
+      b === CMD.READ_SCREEN_PRINT_EXT_GRID
+    );
+  }
+
   /**
-   * Handle records with non-standard framing (e.g. opcode 0x04 from
-   * pub400.com). These records contain valid commands (CLEAR_UNIT, WTD,
-   * READ_*, etc.) but with extra sub-record marker bytes (0x04) between
-   * the GDS header and the actual commands.  We scan for the first known
-   * command byte, skipping 0x04 markers, and hand off to parseCommands.
+   * Parse commands from a data region.
+   *
+   * Per lib5250 session.c:620-629 each command is preceded by an ESC byte
+   * (0x04). We look for ESC+command pairs. As a fallback for non-conforming
+   * servers (e.g. pub400.com) we also accept a bare known-command byte.
    *
    * CRITICAL: the recognition list MUST include every command the host
    * may send alone in its own record. Missing READ_* here would cause a
@@ -139,37 +173,49 @@ export class TN5250Parser {
    * Read handler is the only path that clears `keyboardLocked`.
    */
   private parseCommandsFromOffset(data: Buffer, start: number): boolean {
-    for (let i = start; i < data.length; i++) {
-      // Skip sub-record markers (0x04)
-      if (data[i] === 0x04) continue;
-      // Known command bytes — hand off to normal parsing
-      const b = data[i];
-      if (
-        b === CMD.WRITE_TO_DISPLAY ||
-        b === CMD.CLEAR_UNIT ||
-        b === CMD.CLEAR_UNIT_ALT ||
-        b === CMD.CLEAR_FORMAT_TABLE ||
-        b === CMD.WRITE_STRUCTURED_FIELD ||
-        b === CMD.WRITE_ERROR_CODE ||
-        b === CMD.WRITE_ERROR_CODE_WIN ||
-        b === CMD.READ_INPUT_FIELDS ||
-        b === CMD.READ_MDT_FIELDS ||
-        b === CMD.READ_MDT_FIELDS_ALT ||
-        b === CMD.READ_SCREEN_IMMEDIATE ||
-        b === CMD.READ_IMMEDIATE ||
-        b === CMD.READ_IMMEDIATE_ALT ||
-        b === CMD.SAVE_SCREEN ||
-        b === CMD.RESTORE_SCREEN ||
-        b === CMD.ROLL
-      ) {
-        return this.parseCommands(data, i);
+    let pos = start;
+    let modified = false;
+
+    while (pos < data.length) {
+      const b = data[pos];
+
+      if (b === 0x04) {
+        // ESC byte — per lib5250, next byte is the command
+        if (pos + 1 < data.length && TN5250Parser.isKnownCommand(data[pos + 1])) {
+          pos++; // skip ESC, parseCommands starts at the command byte
+          const result = this.parseCommands(data, pos);
+          modified = modified || result.modified;
+          pos = result.pos;
+        } else {
+          // Stray 0x04 without a valid command following — skip it
+          pos++;
+        }
+        continue;
       }
+
+      // Fallback: bare command byte without ESC prefix (non-conforming servers)
+      if (TN5250Parser.isKnownCommand(b)) {
+        const result = this.parseCommands(data, pos);
+        modified = modified || result.modified;
+        pos = result.pos;
+        continue;
+      }
+
+      // Unknown byte at command level — skip
+      pos++;
     }
-    return false;
+
+    return modified;
   }
 
-  /** Parse one or more 5250 commands starting at offset */
-  private parseCommands(data: Buffer, offset: number): boolean {
+  /**
+   * Parse one or more 5250 commands starting at offset.
+   * Returns the new position and whether the screen was modified.
+   * The command loop terminates when ESC (0x04) is encountered (it is
+   * NOT consumed — the caller re-dispatches it as the start of the next
+   * ESC+command pair, per lib5250 session.c:964-967).
+   */
+  private parseCommands(data: Buffer, offset: number): { pos: number; modified: boolean } {
     let pos = offset;
     let modified = false;
 
@@ -183,6 +229,7 @@ export class TN5250Parser {
           this.screen.resize(24, 80);
           this.screen.keyboardLocked = true;
           this.screen.insertMode = false;
+          this.screen.pendingInsert = false;
           this.screen.savedCursorBeforeError = null;
           this.screen.windowList = [];
           this.screen.selectionFields = [];
@@ -202,6 +249,7 @@ export class TN5250Parser {
           this.screen.resize(27, 132);
           this.screen.keyboardLocked = true;
           this.screen.insertMode = false;
+          this.screen.pendingInsert = false;
           this.screen.savedCursorBeforeError = null;
           this.screen.windowList = [];
           this.screen.selectionFields = [];
@@ -212,13 +260,24 @@ export class TN5250Parser {
           this.winRowOff = 0;
           this.winColOff = 0;
           pos++;
-          // Skip the trailing flag byte (per 5250 spec)
-          if (pos < data.length) pos++;
+          // Read and validate the flag byte (per lib5250 session.c:1148-1156)
+          if (pos < data.length) {
+            const flag = data[pos++];
+            if (flag !== 0x00 && flag !== 0x80) {
+              // Per lib5250: invalid flag; log but continue
+            }
+          }
           modified = true;
           break;
 
         case CMD.CLEAR_FORMAT_TABLE:
+          // Per lib5250 display.c:1949-1956: clear format table, reset cursor,
+          // lock keyboard, and clear insert mode.
           this.screen.fields = [];
+          this.screen.cursorRow = 0;
+          this.screen.cursorCol = 0;
+          this.screen.keyboardLocked = true;
+          this.screen.insertMode = false;
           pos++;
           modified = true;
           break;
@@ -226,59 +285,24 @@ export class TN5250Parser {
         case CMD.WRITE_TO_DISPLAY: {
           pos++; // skip command byte
           // WTD has a CC (control character) — 2 bytes
+          let wtdCC2 = 0;
           if (pos + 1 < data.length) {
             const cc1 = data[pos++];
-            const cc2 = data[pos++];
+            wtdCC2 = data[pos++];
 
-            // CC1 upper 3 bits (0xE0 mask) control MDT reset + null fill.
-            // Per lib5250 session.c:820-851, this is a 7-value switch:
-            let resetNonBypassMdt = false;
-            let resetAllMdt = false;
-            let nullNonBypassMdt = false;
-            let nullNonBypass = false;
-
-            // CC1: lock keyboard for all values except 0x00
-            // Per lib5250 session.c:853-858
-            if ((cc1 & 0xE0) !== 0x00) {
-              this.screen.keyboardLocked = true;
-            }
-
-            switch (cc1 & 0xE0) {
-              case 0x00: break; // no action (don't lock keyboard)
-              case 0x20: break; // reserved / no action in lib5250
-              case 0x40: resetNonBypassMdt = true; break;
-              case 0x60: resetAllMdt = true; break;
-              case 0x80: nullNonBypassMdt = true; break;
-              case 0xA0: resetNonBypassMdt = true; nullNonBypass = true; break;
-              case 0xC0: resetNonBypassMdt = true; nullNonBypassMdt = true; break;
-              case 0xE0: resetAllMdt = true; nullNonBypass = true; break;
-            }
-
-            for (const f of this.screen.fields) {
-              const isInput = this.screen.isInputField(f);
-              // Null fill: clear input field content
-              if (isInput && (nullNonBypass || (nullNonBypassMdt && f.modified))) {
-                const start = this.screen.offset(f.row, f.col);
-                for (let i = start; i < start + f.length; i++) {
-                  this.screen.buffer[i] = ' ';
-                }
-              }
-              // MDT reset
-              if (resetAllMdt || (resetNonBypassMdt && isInput)) {
-                f.modified = false;
-              }
-            }
+            // CC1 handling (shared with Read commands)
+            this.handleCC1(cc1);
 
             // Mark that subsequent SF orders in this WTD should clear stale fields
-            if (resetAllMdt || resetNonBypassMdt) {
-              this.pendingFieldsClear = true;
-            }
+            // (done after handleCC1 since it checks MDT reset flags)
 
             // CC2 handling per lib5250 session.c:1033-1066
-            this.handleCC2(cc2);
+            // Note: CC2 is handled AFTER orders in lib5250 (session.c:1018),
+            // but we handle message/alarm bits here; cursor logic is in parseOrders.
+            this.handleCC2(wtdCC2);
           }
           // Parse orders and data following WTD
-          pos = this.parseOrders(data, pos);
+          pos = this.parseOrders(data, pos, wtdCC2, this.isRestoreScreen);
           modified = true;
           break;
         }
@@ -306,8 +330,8 @@ export class TN5250Parser {
           // IC sets cursor position (but NOT pending insert per spec)
           while (pos < data.length) {
             const c = data[pos];
-            if (c === 0x27) { // ESC — end of error code data
-              break;
+            if (c === 0x04) { // ESC — end of error code data (per lib5250 session.c:765-767)
+              break; // don't advance pos; command loop will see 0x04 for next dispatch
             }
             if (c === ORDER.IC && pos + 2 < data.length) {
               // IC within error code: just move cursor, don't set pending insert
@@ -362,22 +386,23 @@ export class TN5250Parser {
         case CMD.READ_IMMEDIATE:
         case CMD.READ_IMMEDIATE_ALT: {
           // Per lib5250 session.c:2328-2354 (tn5250_session_read_cmd):
-          // Reads 2 CC bytes, handles CC1/CC2, unlocks the keyboard (if
-          // normally locked), and sets read_opcode. The CC bytes have the
-          // same semantics as WTD CC1/CC2.
+          // Reads 2 CC bytes, handles CC1/CC2, clears X_SYSTEM/X_CLOCK,
+          // and unlocks the keyboard only if in normal LOCKED state
+          // (not POSTHELP/error state).
           const readOp = cmd;
           pos++;
           if (pos + 1 < data.length) {
             const cc1 = data[pos++];
             const cc2 = data[pos++];
-            // Lock keyboard if CC1 non-zero (same as WTD behavior)
-            if ((cc1 & 0xE0) !== 0x00) {
-              this.screen.keyboardLocked = true;
-            }
+            this.handleCC1(cc1);
             this.handleCC2(cc2);
           }
-          // Unlock keyboard on Read command — host is requesting input
-          this.screen.keyboardLocked = false;
+          // Per lib5250 session.c:2348-2351: only unlock if in normal
+          // locked state (not error/POSTHELP). We use savedCursorBeforeError
+          // as a proxy for the POSTHELP state.
+          if (this.screen.savedCursorBeforeError === null) {
+            this.screen.keyboardLocked = false;
+          }
           this.screen.readOpcode = readOp;
           modified = true;
           break;
@@ -403,10 +428,22 @@ export class TN5250Parser {
           break;
         }
 
-        case 0x04:
-          // Sub-record marker — skip (appears between commands in some hosts)
+        // Commands recognized by lib5250 but not processed (logged only)
+        case CMD.SAVE_PARTIAL_SCREEN:
+        case CMD.RESTORE_PARTIAL_SCREEN:
+        case CMD.READ_SCREEN_EXTENDED:
+        case CMD.READ_SCREEN_PRINT:
+        case CMD.READ_SCREEN_PRINT_EXTENDED:
+        case CMD.READ_SCREEN_PRINT_GRID:
+        case CMD.READ_SCREEN_PRINT_EXT_GRID:
+          // Per lib5250 session.c: these commands are logged but ignored.
           pos++;
           break;
+
+        case 0x04:
+          // ESC byte — per lib5250 session.c:964-967, return to caller for
+          // re-dispatch as the start of the next ESC+command pair.
+          return { pos, modified };
 
         default:
           // Not a recognized command at this position
@@ -417,14 +454,16 @@ export class TN5250Parser {
       }
     }
 
-    return modified;
+    return { pos, modified };
   }
 
   /**
    * Parse orders and text data within a WTD (or similar) command.
    * Updates the screen buffer and returns the new position.
    */
-  private parseOrders(data: Buffer, pos: number): number {
+  private parseOrders(data: Buffer, pos: number, cc2 = 0, isRestoreScreen = false): number {
+    const oldCursorRow = this.screen.cursorRow;
+    const oldCursorCol = this.screen.cursorCol;
     let currentAddr = this.screen.offset(this.screen.cursorRow, this.screen.cursorCol);
     let currentAttr: number = ATTR.NORMAL;
     let useSymbolCharSet = false; // SA type 0x22 can switch to APL/symbol CGCS
@@ -450,6 +489,8 @@ export class TN5250Parser {
 
     // Helper: write a single rendered character at currentAddr, applying
     // current attributes and resetting the DBCS continuation flag for SBCS.
+    // Per lib5250 dbuffer.c:672-680 (addch + right): wraps around to 0
+    // when reaching the end of the screen buffer.
     const writeChar = (ch: string): void => {
       if (currentAddr < this.screen.size) {
         this.screen.setCharAt(currentAddr, ch);
@@ -458,6 +499,7 @@ export class TN5250Parser {
         this.screen.dbcsCont[currentAddr] = false;
       }
       currentAddr++;
+      if (currentAddr >= this.screen.size) currentAddr = 0;
     };
 
     // Helper: write a DBCS character — glyph in cell N, empty continuation
@@ -470,6 +512,7 @@ export class TN5250Parser {
         this.screen.dbcsCont[currentAddr] = false;
       }
       currentAddr++;
+      if (currentAddr >= this.screen.size) currentAddr = 0;
       if (currentAddr < this.screen.size) {
         this.screen.setCharAt(currentAddr, '');
         this.screen.setAttrAt(currentAddr, currentAttr);
@@ -477,6 +520,7 @@ export class TN5250Parser {
         this.screen.dbcsCont[currentAddr] = true;
       }
       currentAddr++;
+      if (currentAddr >= this.screen.size) currentAddr = 0;
     };
 
     while (pos < data.length) {
@@ -521,20 +565,25 @@ export class TN5250Parser {
           const icCol = data[pos++] - 1 + this.winColOff;
           pendingICRow = icRow;
           pendingICCol = icCol;
+          // Per lib5250 display.c:458-462: IC sets a persistent position
+          // that setCursorHome uses on subsequent WTDs without IC.
+          this.screen.pendingInsert = true;
+          this.screen.pendingInsertRow = icRow;
+          this.screen.pendingInsertCol = icCol;
           break;
         }
 
         case ORDER.MC: {
-          // Move Cursor: 2 bytes follow (row, col) — 1-based from host
+          // Move Cursor: 2 bytes follow (row, col) — 1-based from host.
+          // Per lib5250 session.c:2024-2047: MC does NOT actually move the
+          // cursor or update the display address. It only stores end_y/end_x
+          // for post-WTD cursor positioning (same as IC).
           if (pos + 2 >= data.length) return data.length;
           pos++;
           const mcRow = data[pos++] - 1 + this.winRowOff;
           const mcCol = data[pos++] - 1 + this.winColOff;
-          if (mcRow >= 0 && mcRow < this.screen.rows && mcCol >= 0 && mcCol < this.screen.cols) {
-            this.screen.cursorRow = mcRow;
-            this.screen.cursorCol = mcCol;
-            currentAddr = this.screen.offset(mcRow, mcCol);
-          }
+          pendingICRow = mcRow;
+          pendingICCol = mcCol;
           break;
         }
 
@@ -550,21 +599,26 @@ export class TN5250Parser {
           const charByte = data[pos++];
           const targetAddr = this.screen.offset(raRow, raCol);
           const ch = ebcdicToChar(charByte, this.screen.codePage);
+          // Per lib5250 addch semantics: set char, attribute, and ext attrs
+          const raExt = snapExt();
+          const raFill = () => {
+            this.screen.setCharAt(currentAddr, ch);
+            this.screen.setAttrAt(currentAddr, currentAttr);
+            this.screen.setExtAttrAt(currentAddr, raExt);
+            currentAddr++;
+          };
           if (targetAddr >= currentAddr) {
             while (currentAddr <= targetAddr && currentAddr < this.screen.size) {
-              this.screen.setCharAt(currentAddr, ch);
-              currentAddr++;
+              raFill();
             }
           } else {
             // Wrap-around: fill to end of screen, then from start to target (inclusive)
             while (currentAddr < this.screen.size) {
-              this.screen.setCharAt(currentAddr, ch);
-              currentAddr++;
+              raFill();
             }
             currentAddr = 0;
             while (currentAddr <= targetAddr && currentAddr < this.screen.size) {
-              this.screen.setCharAt(currentAddr, ch);
-              currentAddr++;
+              raFill();
             }
           }
           break;
@@ -580,17 +634,15 @@ export class TN5250Parser {
           const eaRow = data[pos++] - 1 + this.winRowOff;
           const eaCol = data[pos++] - 1 + this.winColOff;
           const eaLength = data[pos++];
-          // Consume (length-1) attribute bytes
+          // Consume (length-1) attribute bytes. Per lib5250 session.c:2131,
+          // only the LAST attribute byte is checked for 0xFF.
           const attrCount = Math.max(0, eaLength - 1);
-          let eraseAll = false;
+          let lastAttr = 0;
           for (let i = 0; i < attrCount && pos < data.length; i++) {
-            if (data[pos] === 0xFF) eraseAll = true;
-            pos++;
+            lastAttr = data[pos++];
           }
-          // lib5250 only erases characters when attribute 0xFF is present
-          // (we don't track extended attributes separately). Default on any
-          // attribute list so the region is cleared — safe for typical hosts.
-          if (eraseAll || attrCount === 0) {
+          // lib5250 only erases characters when the last attribute is 0xFF
+          if (lastAttr === 0xFF) {
             const eaTarget = this.screen.offset(eaRow, eaCol);
             if (eaTarget >= currentAddr) {
               while (currentAddr <= eaTarget && currentAddr < this.screen.size) {
@@ -619,17 +671,24 @@ export class TN5250Parser {
 
         case ORDER.SOH: {
           // Start of Header: variable-length header for input fields.
-          // Per lib5250: SOH clears format table and pending insert cursor.
+          // Per lib5250 session.c:1810-1841: SOH clears format table, clears
+          // pending insert cursor, locks keyboard, and sets X_SYSTEM.
           // Format: [0x01] [length] [data...]
           // The length byte specifies the number of data bytes following it
-          // (NOT including SOH or length byte itself).
+          // (NOT including SOH or length byte itself). Must be 0-7.
           if (pos + 1 >= data.length) return data.length;
           pos++;
           this.screen.fields = [];
           this.screen.selectionFields = [];
+          this.screen.keyboardLocked = true;
+          this.screen.pendingInsert = false;
           pendingICRow = -1;
           pendingICCol = -1;
           const hdrLen = data[pos++];
+          if (hdrLen > 7) {
+            // Per lib5250: invalid SOH length — skip remaining
+            return data.length;
+          }
           // Per lib5250 dbuffer.c:167-178: copy header bytes for later use
           // (byte 3 carries the error message line row).
           const safeLen = Math.max(0, Math.min(hdrLen, data.length - pos));
@@ -740,6 +799,9 @@ export class TN5250Parser {
                     // Fallback: remove the top (last) window
                     this.screen.windowList.pop();
                   }
+                  // Per lib5250 session.c:3495-3502: removing a window also
+                  // destroys all scrollbars.
+                  this.screen.scrollbarList = [];
                   this.winRowOff = 0;
                   this.winColOff = 0;
                   break;
@@ -762,6 +824,22 @@ export class TN5250Parser {
                   this.winRowOff = 0;
                   this.winColOff = 0;
                   break;
+                case WDSF_TYPE.WRITE_DATA: {
+                  // Per lib5250 session.c:3575-3613: write data to the current
+                  // field position. Flag byte followed by EBCDIC data bytes.
+                  if (pos < wdsfEnd) {
+                    const _flagbyte = data[pos++]; // 0x80 = write to entry field
+                    while (pos < wdsfEnd) {
+                      const ch = ebcdicToChar(data[pos++], this.screen.codePage);
+                      if (currentAddr < this.screen.size) {
+                        this.screen.setCharAt(currentAddr, ch);
+                      }
+                      currentAddr++;
+                      if (currentAddr >= this.screen.size) currentAddr = 0;
+                    }
+                  }
+                  break;
+                }
                 default:
                   break;
               }
@@ -845,11 +923,25 @@ export class TN5250Parser {
       afterSBA = false;
     }
 
-    // Apply deferred IC cursor position (last IC wins, per lib5250)
-    if (pendingICRow >= 0 && pendingICCol >= 0) {
+    // Post-WTD cursor positioning per lib5250 session.c:998-1018.
+    // Three-branch logic using CC2 bit 0x40 (IC_ULOCK):
+    const icUlock = (cc2 & 0x40) !== 0;
+    const willUnlock = (cc2 & 0x08) !== 0;
+    const hasIC = pendingICRow >= 0 && pendingICCol >= 0;
+
+    if (hasIC && !icUlock) {
+      // IC/MC position wins
       this.screen.cursorRow = pendingICRow;
       this.screen.cursorCol = pendingICCol;
       this.icApplied = true;
+    } else if ((willUnlock && !icUlock) || isRestoreScreen) {
+      // Cursor home: first input field, or (0,0)
+      this.screen.setCursorHome();
+      this.icApplied = true;
+    } else {
+      // Keep original pre-WTD cursor position
+      this.screen.cursorRow = oldCursorRow;
+      this.screen.cursorCol = oldCursorCol;
     }
 
     return pos;
@@ -1021,7 +1113,8 @@ export class TN5250Parser {
       fcw2,
       attribute: fieldDisplayAttr,
       rawAttrByte,
-      modified: false,
+      // Per lib5250 field.h:148: MDT is bit 3 (0x08) of ffw1 (FFW high byte)
+      modified: inputField ? (ffw1 & 0x08) !== 0 : false,
       continuous: continuous || undefined,
       continuedFirst: contFirst || undefined,
       continuedMiddle: contMiddle || undefined,
@@ -1046,7 +1139,34 @@ export class TN5250Parser {
     };
 
     this.clearStaleFieldsOnce();
-    this.screen.fields.push(field);
+
+    // Per lib5250 session.c:1717-1724: if a field already exists at this
+    // position, modify it rather than adding a duplicate.
+    if (inputField) {
+      const existing = this.screen.fields.find(f => f.row === row && f.col === col);
+      if (existing) {
+        existing.ffw1 = ffw1;
+        existing.ffw2 = ffw2;
+        existing.attribute = fieldDisplayAttr;
+        existing.rawAttrByte = rawAttrByte;
+      } else {
+        this.screen.fields.push(field);
+      }
+    } else {
+      this.screen.fields.push(field);
+    }
+
+    // Per lib5250 session.c:1766-1795: for input fields, write 0x20 (space)
+    // at the position after the end of the field (field separator marker),
+    // so adjacent fields render correctly.
+    if (inputField && fieldLength > 0) {
+      let endAddr = this.screen.offset(row, col) + fieldLength;
+      if (endAddr >= this.screen.size) endAddr -= this.screen.size;
+      if (endAddr < this.screen.size) {
+        this.screen.setCharAt(endAddr, ' ');
+      }
+    }
+
     return pos;
   }
 
@@ -1197,37 +1317,40 @@ export class TN5250Parser {
         const _choiceFlagbyte2 = data[pos + 3];
         const choiceFlagbyte3 = data[pos + 4];
 
-        // Skip if flagbyte3 bits 7-5 are all zero (choice not applicable)
-        if ((choiceFlagbyte3 & 0xE0) !== 0) {
-          // Calculate text offset: skip flags, optional mnemonic/AID/numeric fields
-          let textOff = 5;
-          if (choiceFlagbyte1 & 0x08) textOff++; // mnemonic offset
-          if (choiceFlagbyte1 & 0x04) textOff++; // AID byte
-          const numericSel = choiceFlagbyte1 & 0x03;
-          if (numericSel === 1) textOff++;        // single-digit numeric
-          else if (numericSel === 2) textOff += 2; // double-digit numeric
+        // Per lib5250 session.c:2885-2910: choice availability is determined
+        // by flagbyte1 bits 6-7 (0xC0), not flagbyte3. Include all choices.
+        // Calculate text offset: skip flags, optional mnemonic/AID/numeric fields
+        let textOff = 5;
+        if (choiceFlagbyte1 & 0x08) textOff++; // mnemonic offset
+        if (choiceFlagbyte1 & 0x04) textOff++; // AID byte
+        const numericSel = choiceFlagbyte1 & 0x03;
+        if (numericSel === 1) textOff++;        // single-digit numeric
+        else if (numericSel === 2) textOff += 2; // double-digit numeric
 
-          let text = '';
-          for (let i = textOff; i < minorLen; i++) {
-            text += ebcdicToChar(data[pos + i]);
-          }
-
-          const choiceRow = baseRow + choiceIndex;
-          choices.push({ text, row: choiceRow, col: baseCol });
-          choiceIndex++;
+        let text = '';
+        for (let i = textOff; i < minorLen; i++) {
+          text += ebcdicToChar(data[pos + i]);
         }
+
+        const choiceRow = baseRow + choiceIndex;
+        choices.push({ text, row: choiceRow, col: baseCol });
+        choiceIndex++;
       }
 
       pos += minorLen;
     }
 
-    this.screen.selectionFields.push({
-      row: baseRow,
-      col: baseCol,
-      numRows,
-      numCols: itemSize,
-      choices,
-    });
+    // Per lib5250 session.c:2619-2624: if a selection field already exists at
+    // this position, redefine it rather than creating a duplicate.
+    const existingSel = this.screen.selectionFields.findIndex(
+      s => s.row === baseRow && s.col === baseCol,
+    );
+    const selDef = { row: baseRow, col: baseCol, numRows, numCols: itemSize, choices };
+    if (existingSel >= 0) {
+      this.screen.selectionFields[existingSel] = selDef;
+    } else {
+      this.screen.selectionFields.push(selDef);
+    }
   }
 
   /**
@@ -1376,6 +1499,56 @@ export class TN5250Parser {
     }
   }
 
+  /**
+   * Handle CC1 byte (first control character of WTD / Read commands).
+   * Per lib5250 session.c:812-878.
+   *
+   * CC1 upper 3 bits (0xE0 mask) control keyboard lock, MDT reset,
+   * and null-fill operations on fields.
+   */
+  private handleCC1(cc1: number): void {
+    let resetNonBypassMdt = false;
+    let resetAllMdt = false;
+    let nullNonBypassMdt = false;
+    let nullNonBypass = false;
+
+    // Lock keyboard for all CC1 values except 0x00
+    if ((cc1 & 0xE0) !== 0x00) {
+      this.screen.keyboardLocked = true;
+    }
+
+    switch (cc1 & 0xE0) {
+      case 0x00: break;
+      case 0x20: break; // reserved
+      case 0x40: resetNonBypassMdt = true; break;
+      case 0x60: resetAllMdt = true; break;
+      case 0x80: nullNonBypassMdt = true; break;
+      case 0xA0: resetNonBypassMdt = true; nullNonBypass = true; break;
+      case 0xC0: resetNonBypassMdt = true; nullNonBypassMdt = true; break;
+      case 0xE0: resetAllMdt = true; nullNonBypass = true; break;
+    }
+
+    for (const f of this.screen.fields) {
+      const isInput = this.screen.isInputField(f);
+      // Null fill: clear input field content
+      if (isInput && (nullNonBypass || (nullNonBypassMdt && f.modified))) {
+        const start = this.screen.offset(f.row, f.col);
+        for (let i = start; i < start + f.length; i++) {
+          this.screen.buffer[i] = ' ';
+        }
+      }
+      // MDT reset
+      if (resetAllMdt || (resetNonBypassMdt && isInput)) {
+        f.modified = false;
+      }
+    }
+
+    // Mark that subsequent SF orders in this WTD should clear stale fields
+    if (resetAllMdt || resetNonBypassMdt) {
+      this.pendingFieldsClear = true;
+    }
+  }
+
   /** Clear stale fields when the first SF order arrives after a Reset MDT WTD */
   private clearStaleFieldsOnce(): void {
     if (this.pendingFieldsClear) {
@@ -1475,6 +1648,18 @@ export class TN5250Parser {
         if (!onSignOnScreen) f.ffw1 |= 0x20;
         continue;
       }
+
+      // Native underscore attribute (lower 3 bits = 4, 5, or 6 → UL,
+      // UL+RI, UL+HI) is a strong signal that this is a real input field.
+      // UIM popup screens (e.g. "Exit Interactive SQL", CRTLIB prompter)
+      // use short underscore-attribute fields pre-populated with default
+      // values like "1". Without this check the empty-content rule below
+      // demotes them, which strips the cursor and breaks TAB walking on
+      // those screens. Decoration/label fields don't carry the underscore
+      // attribute, so this exception is safe.
+      const attrType = f.rawAttrByte & 0x07;
+      const hasNativeUnderscore = attrType >= 0x04 && attrType < 0x07;
+      if (hasNativeUnderscore) continue;
 
       // (a) Same-row termination check
       const next = sortedFields[i + 1];

--- a/packages/proxy/src/tn5250/screen.ts
+++ b/packages/proxy/src/tn5250/screen.ts
@@ -28,6 +28,13 @@ interface SavedScreenState {
   fields: FieldDef[];
   cursorRow: number;
   cursorCol: number;
+  // Per lib5250 session.c:1389-1394: save/restore read state and display metadata
+  readOpcode: number;
+  keyboardLocked: boolean;
+  headerData: number[];
+  windowList: WindowDef[];
+  selectionFields: SelectionFieldDef[];
+  scrollbarList: ScrollbarDef[];
 }
 
 export interface WindowDef {
@@ -185,6 +192,17 @@ export class ScreenBuffer {
   savedMsgLine: string[] | null = null;
   /** Row (0-based) where savedMsgLine was captured from. */
   savedMsgLineRow: number = -1;
+  /**
+   * Persistent Insert Cursor position from IC order. Per lib5250
+   * display.c:458-462 (set_pending_insert) and display.c:614-635
+   * (set_cursor_home). Set by IC order, cleared by SOH and CLEAR_UNIT.
+   * When set, setCursorHome goes to this position instead of the first
+   * input field.
+   */
+  pendingInsert = false;
+  pendingInsertRow = 0;
+  pendingInsertCol = 0;
+
   /**
    * Current Read command opcode — set when the host sends a Read command
    * (READ_INPUT_FIELDS, READ_MDT_FIELDS, READ_MDT_FIELDS_ALT, READ_IMMEDIATE,
@@ -363,6 +381,29 @@ export class ScreenBuffer {
     return (field.ffw1 & 0x20) === 0; // BYPASS bit not set
   }
 
+  /**
+   * Set cursor to "home" position per lib5250 display.c:614-635:
+   *   1) If pending insert (from a prior IC order), go to the IC position
+   *   2) Otherwise, first position of the first non-bypass field
+   *   3) Otherwise, (0,0)
+   */
+  setCursorHome(): void {
+    if (this.pendingInsert) {
+      this.cursorRow = this.pendingInsertRow;
+      this.cursorCol = this.pendingInsertCol;
+      return;
+    }
+    for (const f of this.fields) {
+      if (this.isInputField(f)) {
+        this.cursorRow = f.row;
+        this.cursorCol = f.col;
+        return;
+      }
+    }
+    this.cursorRow = 0;
+    this.cursorCol = 0;
+  }
+
   /** Whether a field is highlighted (high intensity) */
   isHighlighted(field: FieldDef): boolean {
     return field.attribute === 0x22;
@@ -413,9 +454,24 @@ export class ScreenBuffer {
     this.savedMsgLineRow = -1;
   }
 
-  /** Whether a field has the underscore display attribute */
+  /** Whether a field should render with an underline.
+   *
+   *  Two sources:
+   *  1. Explicit 5250 underscore attribute — lower 3 bits of the attribute
+   *     byte encode display type: 4=UL, 5=UL+RI, 6=UL+HI (exclude 7=ND).
+   *     Covers all color+underscore combinations (e.g. green+UL=0x24,
+   *     turquoise+UL=0x34, blue+UL=0x3C, etc.).
+   *  2. Convention — real 5250 clients (IBM ACS, Mocha) visually underline
+   *     ALL input fields, even when the host leaves the attribute as
+   *     NORMAL (0x20). IBM i's default "Selection or command" menu field
+   *     is one such case: the host sends 0x20 but every production 5250
+   *     client still renders an underline so users can see the input zone.
+   *     Password (non-display) fields never get underline. */
   isUnderscored(field: FieldDef): boolean {
-    return field.attribute === 0x24;
+    const type = field.attribute & 0x07;
+    if (type >= 0x04 && type < 0x07) return true;
+    // Apply input-field convention (skip password / non-display)
+    return this.isInputField(field) && !this.isNonDisplay(field);
   }
 
   /** Whether a field has the FFW mandatory entry flag (CHECK(ME)) */
@@ -464,7 +520,9 @@ export class ScreenBuffer {
     }
   }
 
-  /** Save current screen state to the stack */
+  /** Save current screen state to the stack.
+   *  Per lib5250 session.c:1377-1404: saves display buffer, fields, cursor,
+   *  and read state so they can be restored later. */
   saveState(): void {
     this.screenStack.push({
       buffer: [...this.buffer],
@@ -474,6 +532,12 @@ export class ScreenBuffer {
       fields: this.fields.map(f => ({ ...f })),
       cursorRow: this.cursorRow,
       cursorCol: this.cursorCol,
+      readOpcode: this.readOpcode,
+      keyboardLocked: this.keyboardLocked,
+      headerData: [...this.headerData],
+      windowList: this.windowList.map(w => ({ ...w })),
+      selectionFields: this.selectionFields.map(s => ({ ...s, choices: [...s.choices] })),
+      scrollbarList: this.scrollbarList.map(sb => ({ ...sb })),
     });
   }
 
@@ -488,6 +552,12 @@ export class ScreenBuffer {
     this.fields = state.fields;
     this.cursorRow = state.cursorRow;
     this.cursorCol = state.cursorCol;
+    this.readOpcode = state.readOpcode;
+    this.keyboardLocked = state.keyboardLocked;
+    this.headerData = state.headerData;
+    this.windowList = state.windowList;
+    this.selectionFields = state.selectionFields;
+    this.scrollbarList = state.scrollbarList;
     return true;
   }
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "green-screen-react",
-  "version": "1.2.6",
+  "version": "1.3.0",
   "description": "Multi-protocol legacy terminal React component (TN5250, TN3270, VT, HP 6530)",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/react/src/adapters/types.ts
+++ b/packages/react/src/adapters/types.ts
@@ -100,4 +100,12 @@ export interface TerminalAdapter {
   disconnect(): Promise<SendResult>;
   /** Reconnect to the host */
   reconnect(): Promise<SendResult>;
+  /**
+   * Subscribe to pushed screen updates. Returns an unsubscribe function.
+   * Adapters that support server-initiated push (e.g. WebSocket) should
+   * implement this — the React hooks use it to surface updates to state
+   * immediately rather than waiting for the next poll tick. Adapters
+   * without push support may omit it; the hooks fall back to polling.
+   */
+  onScreen?(listener: (screen: ScreenData) => void): () => void;
 }

--- a/packages/react/src/components/GreenScreenTerminal.tsx
+++ b/packages/react/src/components/GreenScreenTerminal.tsx
@@ -1,32 +1,15 @@
-import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
+import React, { useState, useEffect, useLayoutEffect, useRef, useCallback, useMemo } from 'react';
 import type { TerminalAdapter, ScreenData, ConnectionStatus, Field, TerminalProtocol, ProtocolProfile, ConnectConfig } from '../adapters/types';
 import { RestAdapter } from '../adapters/RestAdapter';
 import { WebSocketAdapter } from '../adapters/WebSocketAdapter';
-import { useTerminalScreen, useTerminalInput, useTerminalConnection } from '../hooks/useTerminal';
-import { useTypingAnimation } from '../hooks/useTypingAnimation';
+import { useAutoReconnect } from '../hooks/useAutoReconnect';
+import { useTerminalState } from '../hooks/useTerminalState';
 import { getProtocolProfile } from '../protocols/registry';
 import { TerminalBootLoader as DefaultBootLoader } from './TerminalBootLoader';
-import { TerminalIcon, WifiIcon, WifiOffIcon, AlertTriangleIcon, RefreshIcon, KeyIcon, MinimizeIcon, KeyboardIcon } from './Icons';
+import { TerminalIcon, WifiIcon, WifiOffIcon, AlertTriangleIcon, RefreshIcon, KeyIcon, MinimizeIcon, KeyboardIcon, UnplugIcon } from './Icons';
 import { InlineSignIn } from './InlineSignIn';
 import { decodeAttrByte, decodeExtColor, decodeExtHighlight, cssVarForColor, mergeExtAttr, extColorIsReverse } from '../utils/attribute';
 import { validateMod10, validateMod11, filterFieldInput } from '../utils/validation';
-
-/**
- * True if the screen content is effectively empty — all spaces, NULs, or
- * whitespace. Used to detect the "host blanked the screen but hasn't sent
- * replacement content yet" transit state.
- */
-function isBlankContent(content: string | undefined): boolean {
-  if (!content) return true;
-  for (let i = 0; i < content.length; i++) {
-    const ch = content.charCodeAt(i);
-    // Skip whitespace (space, tab, newline, CR), NUL, and non-breaking space
-    if (ch !== 0x20 && ch !== 0x09 && ch !== 0x0a && ch !== 0x0d && ch !== 0x00 && ch !== 0xa0) {
-      return false;
-    }
-  }
-  return true;
-}
 
 /** Format milliseconds as M:SS for the X CLOCK busy indicator. */
 function formatBusyClock(ms: number): string {
@@ -55,6 +38,32 @@ function aidByteToKeyName(aid: number): string | null {
   return null;
 }
 
+/**
+ * Compute the portion of a field that falls on a given row, handling
+ * wrap-around for multi-row fields (common on IBM i command lines where a
+ * single field spans 2-3 rows). Returns null if the field doesn't touch
+ * this row. Otherwise returns { col, length } for the slice on this row.
+ *
+ * Example: field at (row 19, col 7, length 153) with cols=80:
+ *   row 19 → { col: 7, length: 73 }   (73 chars: col 7..79)
+ *   row 20 → { col: 0, length: 80 }   (next 80 chars: col 0..79)
+ *   row 21 → null (len 73+80=153 exhausted)
+ */
+function fieldSliceForRow(
+  field: { row: number; col: number; length: number },
+  rowIndex: number,
+  cols: number,
+): { col: number; length: number } | null {
+  const rowDelta = rowIndex - field.row;
+  if (rowDelta < 0) return null;
+  const offsetFromStart = rowDelta === 0 ? 0 : (cols - field.col) + (rowDelta - 1) * cols;
+  if (offsetFromStart >= field.length) return null;
+  const sliceCol = rowDelta === 0 ? field.col : 0;
+  const sliceLen = Math.min(cols - sliceCol, field.length - offsetFromStart);
+  if (sliceLen <= 0) return null;
+  return { col: sliceCol, length: sliceLen };
+}
+
 /* ── No-op adapter (placeholder before connection) ───────────────── */
 
 const noopResult = { success: false, error: 'No adapter configured' };
@@ -70,6 +79,16 @@ const noopAdapter: TerminalAdapter = {
 };
 
 /* ── Component Props ──────────────────────────────────────────────── */
+
+/** State passed to the header render prop */
+export interface TerminalHeaderState {
+  connectionStatus: ConnectionStatus | null;
+  keyboardLocked: boolean;
+  insertMode: boolean;
+  isFocused: boolean;
+  reconnect: () => void;
+  reconnecting: boolean;
+}
 
 export interface GreenScreenTerminalProps {
   /** Adapter for communicating with the terminal backend (optional — auto-created from sign-in form or baseUrl) */
@@ -100,11 +119,16 @@ export interface GreenScreenTerminalProps {
   embedded?: boolean;
   /** Show the header bar (default true) */
   showHeader?: boolean;
+  /** Custom header: ReactNode, render prop with terminal state, or false to hide.
+   *  When provided, overrides showHeader/embedded/headerRight/statusActions. */
+  header?: React.ReactNode | ((state: TerminalHeaderState) => React.ReactNode) | false;
   /** Enable typing animation (default false) */
   typingAnimation?: boolean;
   /** Typing animation budget in ms (default 60) */
   typingBudgetMs?: number;
 
+  /** Auto-create a default WebSocketAdapter when no adapter/baseUrl/workerUrl is provided (default true) */
+  autoConnect?: boolean;
   /** Show inline sign-in form when disconnected (default true) */
   inlineSignIn?: boolean;
   /** Default protocol for the sign-in form dropdown (default 'tn5250') */
@@ -130,10 +154,35 @@ export interface GreenScreenTerminalProps {
   onNotification?: (message: string, type: 'info' | 'error') => void;
   /** Callback when screen content changes */
   onScreenChange?: (screen: ScreenData) => void;
+  /** Callback fired after the terminal's built-in disconnect button is clicked
+   *  and the adapter has disconnected. Use to clean up external state
+   *  (session storage, parent component state, etc.). */
+  onDisconnect?: () => void;
   /** Callback for minimize action (embedded mode) */
   onMinimize?: () => void;
   /** Show the keyboard-shortcuts button in the header (default true) */
   showShortcutsButton?: boolean;
+
+  /** Persist focus state to localStorage across page reloads (default true) */
+  persistFocus?: boolean;
+
+  /** When true, the terminal treats itself as always focused:
+   *   (a) clicks outside the terminal don't unfocus it (click-outside
+   *       handler is disabled);
+   *   (b) any document-level keydown that lands on a non-form element
+   *       refocuses the hidden input so keystrokes flow to the terminal.
+   *
+   *  Use this for single-terminal host pages where the user should never
+   *  need to click back into the terminal to keep typing. When there are
+   *  other editable controls on the page (form fields, editors), keep this
+   *  off and let the regular click-to-focus model decide. */
+  alwaysFocused?: boolean;
+
+  /** Built-in visual theme preset. Applied as a `gs-theme-*` class on the
+   *  root `.gs-terminal` element so CSS variables resolve to theme-specific
+   *  values. Integrators can also override individual CSS variables directly
+   *  on a parent element for fully custom palettes. Default: 'modern'. */
+  theme?: 'modern' | 'classic';
 
   /** Additional CSS class name */
   className?: string;
@@ -168,8 +217,10 @@ export function GreenScreenTerminal({
   maxReconnectAttempts: maxAttempts = 5,
   embedded = false,
   showHeader = true,
+  header,
   typingAnimation = false,
   typingBudgetMs = 60,
+  autoConnect = true,
   inlineSignIn = true,
   defaultProtocol: signInDefaultProtocol,
   onSignIn,
@@ -181,15 +232,18 @@ export function GreenScreenTerminal({
   overlay,
   onNotification,
   onScreenChange,
+  onDisconnect,
   onMinimize,
   showShortcutsButton = true,
+  persistFocus = true,
+  alwaysFocused = false,
+  theme = 'modern',
   className,
   style,
 }: GreenScreenTerminalProps) {
   const profile = customProfile ?? getProtocolProfile(protocol);
 
-  // --- Resolve adapter: explicit > baseUrl > workerUrl > internal (from sign-in) > default WebSocket > noop ---
-  const [internalAdapter, setInternalAdapter] = useState<TerminalAdapter | null>(null);
+  // --- Resolve adapter: explicit > baseUrl > workerUrl > default WebSocket > noop ---
   const baseUrlAdapter = useMemo(
     () => baseUrl ? new RestAdapter({ baseUrl }) : null,
     [baseUrl],
@@ -200,97 +254,36 @@ export function GreenScreenTerminal({
   );
   // Default WebSocketAdapter (auto-detects env vars, falls back to localhost:3001) when no adapter is configured
   const defaultWsAdapter = useMemo(
-    () => (!externalAdapter && !baseUrl && !workerUrl) ? new WebSocketAdapter() : null,
-    [externalAdapter, baseUrl, workerUrl],
+    () => (autoConnect && !externalAdapter && !baseUrl && !workerUrl) ? new WebSocketAdapter() : null,
+    [autoConnect, externalAdapter, baseUrl, workerUrl],
   );
-  const adapter = externalAdapter ?? baseUrlAdapter ?? workerUrlAdapter ?? internalAdapter ?? defaultWsAdapter ?? noopAdapter;
+  const adapter = externalAdapter ?? baseUrlAdapter ?? workerUrlAdapter ?? defaultWsAdapter ?? noopAdapter;
   const isUsingDefaultAdapter = adapter === defaultWsAdapter;
 
-  // --- Data sources ---
-  const shouldPoll = pollInterval > 0 && !externalScreenData;
-  const { data: polledScreenData, error: screenError } = useTerminalScreen(adapter, pollInterval, shouldPoll);
-  const { sendText: _sendText, sendKey: _sendKey } = useTerminalInput(adapter);
-  const { connect, reconnect, loading: reconnecting, error: connectError } = useTerminalConnection(adapter);
-
-  const incomingScreenData = externalScreenData ?? polledScreenData;
-
-  // --- Sticky last-contentful screen ----------------------------------
-  // Some IBM i operations send a CLEAR_UNIT record and then take multiple
-  // seconds to send the replacement WRITE_TO_DISPLAY. In between, the
-  // proxy emits a fully blank locked screen, which would render as a black
-  // flash that makes the terminal feel broken. Stash the last non-blank
-  // snapshot and substitute it back in whenever we're in that transit
-  // state — this keeps the old screen visible (with the X II lock badge)
-  // until the host actually finishes responding.
-  const lastContentfulRef = useRef<ScreenData | null>(null);
-  useEffect(() => {
-    if (incomingScreenData && !isBlankContent(incomingScreenData.content)) {
-      lastContentfulRef.current = incomingScreenData;
-    }
-  }, [incomingScreenData]);
-
-  // True waiting state on the wire: host blanked the buffer AND the
-  // keyboard is still locked. Errors (WRITE_ERROR_CODE) paint text on the
-  // message line, so this never matches an error screen.
-  const isBlankLocked = !!(
-    incomingScreenData &&
-    incomingScreenData.keyboard_locked &&
-    isBlankContent(incomingScreenData.content)
-  );
-
-  const rawScreenData = useMemo(() => {
-    if (isBlankLocked && lastContentfulRef.current) {
-      return { ...lastContentfulRef.current, keyboard_locked: true };
-    }
-    return incomingScreenData;
-  }, [incomingScreenData, isBlankLocked]);
-
-  // --- Busy "X CLOCK" overlay -----------------------------------------
-  // Shows after 600ms of a blank+locked state to reassure the user that
-  // the host is just slow, not broken. The deferral prevents flashing on
-  // fast operations where the host clears and rewrites within one frame.
-  // Only triggers on true waiting state (isBlankLocked) so error screens
-  // — which paint error text and therefore are never blank — don't
-  // latch it on indefinitely.
-  const BUSY_OVERLAY_DELAY_MS = 600;
-  const [lockElapsedMs, setLockElapsedMs] = useState(0);
-  useEffect(() => {
-    if (!isBlankLocked) {
-      setLockElapsedMs(0);
-      return;
-    }
-    const start = Date.now();
-    setLockElapsedMs(0);
-    const id = setInterval(() => setLockElapsedMs(Date.now() - start), 250);
-    return () => clearInterval(id);
-  }, [isBlankLocked]);
-  const showBusyOverlay = isBlankLocked && lockElapsedMs >= BUSY_OVERLAY_DELAY_MS;
-
-  const connStatus = externalStatus ?? (rawScreenData ? { connected: true, status: 'authenticated' as const } : { connected: false, status: 'disconnected' as const });
-
-  // Typing animation
-  const { displayedContent, animatedCursorPos } = useTypingAnimation(
-    rawScreenData?.content,
+  // --- Core terminal state (screen data, connection, busy overlay) ---
+  const {
+    screenData,
+    rawScreenData,
+    connectionStatus: connStatus,
+    sendText,
+    sendKey,
+    connect,
+    reconnect,
+    reconnecting,
+    connectError,
+    screenError,
+    showBusyOverlay,
+    busyElapsedMs: lockElapsedMs,
+    animatedCursorPos,
+  } = useTerminalState({
+    adapter,
+    pollInterval,
+    externalScreenData,
+    externalStatus,
     typingAnimation,
     typingBudgetMs,
-  );
-
-  const screenData = useMemo(() => {
-    if (!rawScreenData) return null;
-    return { ...rawScreenData, content: displayedContent };
-  }, [rawScreenData, displayedContent]);
-
-  // Notify parent on screen changes
-  const prevScreenSigRef = useRef<string | undefined>(undefined);
-  useEffect(() => {
-    if (screenData && onScreenChange && screenData.screen_signature !== prevScreenSigRef.current) {
-      prevScreenSigRef.current = screenData.screen_signature;
-      onScreenChange(screenData);
-    }
-  }, [screenData, onScreenChange]);
-
-  const sendText = useCallback(async (text: string) => _sendText(text), [_sendText]);
-  const sendKey = useCallback(async (key: string) => _sendKey(key), [_sendKey]);
+    onScreenChange,
+  });
 
   // --- Optimistic edits ---
   // Characters typed by the user are applied optimistically to the displayed
@@ -313,10 +306,21 @@ export function GreenScreenTerminal({
   const [isFocused, setIsFocused] = useState(false);
   const [showShortcuts, setShowShortcuts] = useState(false);
   const [fkeyPage, setFkeyPage] = useState(0); // 0 = F1-F12, 1 = F13-F24
+  // Draggable shortcuts panel: position is viewport-relative (position: fixed).
+  // Null until the panel first opens; then seeded from terminal bottom-right.
+  const [shortcutsPos, setShortcutsPos] = useState<{ x: number; y: number } | null>(null);
+  const [isDraggingShortcuts, setIsDraggingShortcuts] = useState(false);
+  const shortcutsDragOffsetRef = useRef<{ dx: number; dy: number }>({ dx: 0, dy: 0 });
+  const shortcutsPanelRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const terminalRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const [syncedCursor, setSyncedCursor] = useState<{ row: number; col: number } | null>(null);
+  // Optimistic keyboard lock — set instantly when the user presses a submit
+  // key (Enter/F-key/PageUp/PageDown) so the X II badge appears without
+  // waiting for the proxy's round-trip. Cleared when rawScreenData content
+  // changes (meaning the proxy has responded with a new screen).
+  const [optimisticLock, setOptimisticLock] = useState(false);
   const prevRawContentRef = useRef('');
 
   useEffect(() => {
@@ -324,48 +328,22 @@ export function GreenScreenTerminal({
     if (prevRawContentRef.current && newContent && newContent !== prevRawContentRef.current) {
       setSyncedCursor(null);
       setInputText('');
+      setOptimisticLock(false);
     }
     prevRawContentRef.current = newContent;
   }, [rawScreenData?.content]);
 
   // --- Auto-reconnect ---
-  const [autoReconnectAttempt, setAutoReconnectAttempt] = useState(0);
-  const [isAutoReconnecting, setIsAutoReconnecting] = useState(false);
-  const reconnectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const wasConnectedRef = useRef(false);
-  const isConnectedRef = useRef(false);
-
-  useEffect(() => { isConnectedRef.current = connStatus?.connected ?? false; }, [connStatus?.connected]);
-
-  useEffect(() => {
-    if (!autoReconnectEnabled) return;
-    const isConnected = connStatus?.connected;
-
-    if (isConnected) {
-      wasConnectedRef.current = true;
-      if (reconnectTimeoutRef.current) { clearTimeout(reconnectTimeoutRef.current); reconnectTimeoutRef.current = null; }
-      setAutoReconnectAttempt(0);
-      setIsAutoReconnecting(false);
-    } else if (wasConnectedRef.current && !isConnected && !isAutoReconnecting && !reconnecting) {
-      if (autoReconnectAttempt < maxAttempts) {
-        setIsAutoReconnecting(true);
-        const delay = Math.pow(2, autoReconnectAttempt) * 1000;
-        reconnectTimeoutRef.current = setTimeout(async () => {
-          if (isConnectedRef.current) { setIsAutoReconnecting(false); return; }
-          onNotification?.(`Auto-reconnect attempt ${autoReconnectAttempt + 1}/${maxAttempts}`, 'info');
-          try {
-            const result = await reconnect();
-            if (!result?.success) setAutoReconnectAttempt(prev => prev + 1);
-          } catch {
-            onNotification?.('Auto-reconnect failed', 'error');
-            setAutoReconnectAttempt(prev => prev + 1);
-          }
-          setIsAutoReconnecting(false);
-        }, delay);
-      }
-    }
-    return () => { if (reconnectTimeoutRef.current) clearTimeout(reconnectTimeoutRef.current); };
-  }, [connStatus?.connected, autoReconnectAttempt, isAutoReconnecting, reconnecting, reconnect, autoReconnectEnabled, maxAttempts, onNotification]);
+  const {
+    attempt: autoReconnectAttempt,
+    isReconnecting: isAutoReconnecting,
+    reset: resetAutoReconnect,
+  } = useAutoReconnect(
+    connStatus?.connected ?? false,
+    reconnecting,
+    reconnect,
+    { enabled: autoReconnectEnabled, maxAttempts: maxAttempts, onNotification },
+  );
 
   // --- Inline sign-in ---
   const [connecting, setConnecting] = useState(false);
@@ -379,14 +357,6 @@ export function GreenScreenTerminal({
     setConnecting(true);
     setSignInError(null);
     try {
-      // Auto-create adapter from sign-in config when no external adapter is provided
-      if (!externalAdapter && !baseUrlAdapter) {
-        const port = config.port ? `:${config.port}` : '';
-        const newAdapter = new RestAdapter({ baseUrl: `http://${config.host}${port}` });
-        setInternalAdapter(newAdapter);
-        await newAdapter.connect(config);
-        return;
-      }
       await connect(config);
     } catch (err) {
       setSignInError(err instanceof Error ? err.message : String(err));
@@ -394,7 +364,7 @@ export function GreenScreenTerminal({
     }
     // Note: connecting is cleared by the screenData effect below, not here —
     // the connect() promise may resolve before the screen is actually ready.
-  }, [connect, onSignIn, externalAdapter, baseUrlAdapter]);
+  }, [connect, onSignIn]);
 
   // Clear connecting state when screen data arrives or connection is confirmed
   useEffect(() => {
@@ -423,9 +393,9 @@ export function GreenScreenTerminal({
   // --- Focus management ---
   const FOCUS_STORAGE_KEY = 'gs-terminal-focused';
 
-  // Restore focus from localStorage on mount (if auto-focus enabled)
+  // Restore focus from localStorage on mount (if auto-focus enabled and persistence enabled)
   useEffect(() => {
-    if (!autoFocusDisabled && !readOnly) {
+    if (!autoFocusDisabled && !readOnly && persistFocus) {
       try {
         if (localStorage.getItem(FOCUS_STORAGE_KEY) === 'true') {
           setIsFocused(true);
@@ -436,9 +406,9 @@ export function GreenScreenTerminal({
 
   // Persist focus state to localStorage
   useEffect(() => {
-    if (autoFocusDisabled) return;
+    if (autoFocusDisabled || !persistFocus) return;
     try { localStorage.setItem(FOCUS_STORAGE_KEY, String(isFocused)); } catch { /* noop */ }
-  }, [isFocused, autoFocusDisabled]);
+  }, [isFocused, autoFocusDisabled, persistFocus]);
 
   // Sync DOM focus with isFocused state
   useEffect(() => {
@@ -456,16 +426,112 @@ export function GreenScreenTerminal({
   }, [screenData?.content, autoFocusDisabled, readOnly]);
 
   useEffect(() => {
+    // Skip click-outside unfocus when alwaysFocused is on — the terminal
+    // stays "focused" regardless of where the user clicks.
+    if (alwaysFocused) return;
     const handleClickOutside = (event: MouseEvent) => {
       if (containerRef.current && !containerRef.current.contains(event.target as Node)) setIsFocused(false);
     };
     if (isFocused) document.addEventListener('mousedown', handleClickOutside);
     return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, [isFocused]);
+  }, [isFocused, alwaysFocused]);
+
+  // alwaysFocused: aggressively steer keyboard focus to the terminal input.
+  // Keeps typing flowing into the terminal even after the user clicks on a
+  // non-form area of the page (e.g. the theme sticker, the demo footer,
+  // or empty space around the terminal). Form controls (input/select/etc)
+  // are whitelisted so the user can still interact with other UI — only
+  // "inert" page clicks get hijacked.
+  useEffect(() => {
+    if (!alwaysFocused || readOnly) return;
+    const isFormTarget = (el: Element | null): boolean => {
+      if (!el) return false;
+      return !!el.closest('input, select, textarea, button, a, [contenteditable="true"]');
+    };
+    const refocusInput = () => {
+      const input = inputRef.current;
+      if (input && document.activeElement !== input) input.focus();
+      setIsFocused(true);
+    };
+    const onMouseDown = (e: MouseEvent) => {
+      if (isFormTarget(e.target as Element)) return;
+      // setTimeout so the click event can still fire its own handlers first.
+      setTimeout(refocusInput, 0);
+    };
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (isFormTarget(e.target as Element)) return;
+      refocusInput();
+    };
+    // Initial focus on mount
+    refocusInput();
+    document.addEventListener('mousedown', onMouseDown);
+    document.addEventListener('keydown', onKeyDown, true);
+    return () => {
+      document.removeEventListener('mousedown', onMouseDown);
+      document.removeEventListener('keydown', onKeyDown, true);
+    };
+  }, [alwaysFocused, readOnly]);
 
   useEffect(() => {
     if (readOnly && isFocused) { setIsFocused(false); inputRef.current?.blur(); }
   }, [readOnly, isFocused]);
+
+  // --- Shortcuts panel: seed initial position & track drag ---
+  // Seed position from the terminal's bottom-right corner on first open
+  // (matches the prior absolute-positioned layout). Uses useLayoutEffect so
+  // the panel paints in its final spot without a flash at (0,0).
+  useLayoutEffect(() => {
+    if (showShortcuts && !shortcutsPos && shortcutsPanelRef.current && containerRef.current) {
+      const tRect = containerRef.current.getBoundingClientRect();
+      const pRect = shortcutsPanelRef.current.getBoundingClientRect();
+      const margin = 12;
+      const x = Math.max(0, Math.min(tRect.right - pRect.width - margin, window.innerWidth - pRect.width));
+      const y = Math.max(0, Math.min(tRect.bottom - pRect.height - margin, window.innerHeight - pRect.height));
+      setShortcutsPos({ x, y });
+    }
+  }, [showShortcuts, shortcutsPos]);
+
+  // Reset saved position when the panel closes so the next open re-seeds
+  // from the current terminal location (handles layout changes between opens).
+  useEffect(() => {
+    if (!showShortcuts) setShortcutsPos(null);
+  }, [showShortcuts]);
+
+  // Track dragging — attach document-level listeners while a drag is active
+  // so the drag continues even if the cursor leaves the panel.
+  useEffect(() => {
+    if (!isDraggingShortcuts) return;
+    const onMove = (e: MouseEvent) => {
+      const panel = shortcutsPanelRef.current;
+      if (!panel) return;
+      const rect = panel.getBoundingClientRect();
+      const nextX = e.clientX - shortcutsDragOffsetRef.current.dx;
+      const nextY = e.clientY - shortcutsDragOffsetRef.current.dy;
+      // Clamp inside viewport bounds
+      const maxX = window.innerWidth - rect.width;
+      const maxY = window.innerHeight - rect.height;
+      setShortcutsPos({
+        x: Math.max(0, Math.min(nextX, maxX)),
+        y: Math.max(0, Math.min(nextY, maxY)),
+      });
+    };
+    const onUp = () => setIsDraggingShortcuts(false);
+    document.addEventListener('mousemove', onMove);
+    document.addEventListener('mouseup', onUp);
+    return () => {
+      document.removeEventListener('mousemove', onMove);
+      document.removeEventListener('mouseup', onUp);
+    };
+  }, [isDraggingShortcuts]);
+
+  const startShortcutsDrag = useCallback((e: React.MouseEvent) => {
+    const panel = shortcutsPanelRef.current;
+    if (!panel) return;
+    const rect = panel.getBoundingClientRect();
+    shortcutsDragOffsetRef.current = { dx: e.clientX - rect.left, dy: e.clientY - rect.top };
+    setIsDraggingShortcuts(true);
+    e.preventDefault();
+  }, []);
 
   const screenContentRef = useRef<HTMLDivElement>(null);
   const charWidthRef = useRef<number>(0);
@@ -489,9 +555,16 @@ export function GreenScreenTerminal({
       contentEl.removeChild(span);
     }
 
+    // .gs-screen-content has padding (12px top, 16px left). Subtract it so
+    // (x, y) is measured from the first character cell, not the padded box
+    // edge. Without this, clicking in the lower half of a visual row maps
+    // to the next row down, and the column lands 1-2 cells to the right.
     const rect = contentEl.getBoundingClientRect();
-    const x = e.clientX - rect.left;
-    const y = e.clientY - rect.top;
+    const cs = window.getComputedStyle(contentEl);
+    const padLeft = parseFloat(cs.paddingLeft) || 0;
+    const padTop = parseFloat(cs.paddingTop) || 0;
+    const x = e.clientX - rect.left - padLeft;
+    const y = e.clientY - rect.top - padTop;
     const ROW_HEIGHT = 21;
     const charWidth = charWidthRef.current;
     if (!charWidth) return;
@@ -505,9 +578,10 @@ export function GreenScreenTerminal({
     // Pointer AID (FCW 0x8Axx): if the clicked field declares a pointer AID,
     // send it as a key press and skip the normal cursor-move. Per IBM 5250
     // Functions Reference this is the defined "mouse click on field" behavior.
-    const clickedField = screenData.fields.find(f =>
-      f.row === clickedRow && clickedCol >= f.col && clickedCol < f.col + f.length,
-    );
+    const clickedField = screenData.fields.find(f => {
+      const slice = fieldSliceForRow(f, clickedRow, screenData.cols || profile.defaultCols);
+      return !!slice && clickedCol >= slice.col && clickedCol < slice.col + slice.length;
+    });
     const ptrAid = clickedField && (clickedField as any).pointer_aid as number | undefined;
     if (ptrAid) {
       // Map AID byte back to a key name. Common cases: 0xF1 ENTER, 0x31-0x3C F1-F12.
@@ -520,25 +594,38 @@ export function GreenScreenTerminal({
       }
     }
 
-    // Send cursor position to proxy (async, fire-and-forget for responsiveness)
+    // Set the click position optimistically and fire the proxy request.
+    // Intentionally fire-and-forget — do NOT chain .then() to update
+    // syncedCursor from the response. WebSocketAdapter.sendAndWaitForScreen
+    // has a single pending-resolver slot: when two setCursor calls overlap,
+    // the second one flushes the first's resolver with stale this.screen,
+    // then the first proxy cursor message resolves the second's resolver —
+    // promises get cross-wired with responses. Since the proxy's setCursor
+    // is a trivial clamp (no snapping), trust the optimistic value. The
+    // proxy's cursor message still updates this.screen.cursor_col for the
+    // next render's fallback.
     setSyncedCursor({ row: clickedRow, col: clickedCol });
-    adapter.setCursor?.(clickedRow, clickedCol).then(r => {
-      if (r?.cursor_row !== undefined) {
-        setSyncedCursor({ row: r.cursor_row, col: r.cursor_col! });
-      }
-    });
+    adapter.setCursor?.(clickedRow, clickedCol);
   }, [readOnly, screenData, adapter, sendKey]);
 
   // --- Field helpers ---
   const getCurrentField = useCallback(() => {
     const fields = screenData?.fields || [];
+    const cols = screenData?.cols || profile.defaultCols;
     const cursorRow = syncedCursor?.row ?? screenData?.cursor_row ?? 0;
     const cursorCol = syncedCursor?.col ?? screenData?.cursor_col ?? 0;
+    // Use fieldSliceForRow so multi-row wrapping input fields (e.g. IBM i
+    // command lines) match a cursor sitting on any of their continuation
+    // rows, not just the first row.
     for (const field of fields) {
-      if (field.is_input && field.row === cursorRow && cursorCol >= field.col && cursorCol < field.col + field.length) return field;
+      if (!field.is_input) continue;
+      const slice = fieldSliceForRow(field, cursorRow, cols);
+      if (!slice) continue;
+      // Inclusive trailing bound — see note in cursorInInputField.
+      if (cursorCol >= slice.col && cursorCol <= slice.col + slice.length) return field;
     }
     return null;
-  }, [screenData, syncedCursor]);
+  }, [screenData, syncedCursor, profile.defaultCols]);
 
   /**
    * Extract the text content of a field from the current screen display.
@@ -585,16 +672,16 @@ export function GreenScreenTerminal({
     // Ctrl+R: Reset (clear keyboard lock and error line)
     if (e.ctrlKey && e.key === 'r') {
       e.preventDefault();
-      const kr = await sendKey('RESET');
-      if (kr.cursor_row !== undefined) setSyncedCursor({ row: kr.cursor_row, col: kr.cursor_col! });
+      setSyncedCursor(null);
+      sendKey('RESET');
       return;
     }
 
     // Ctrl+Enter: Field Exit (right-adjust and advance)
     if (e.ctrlKey && e.key === 'Enter') {
       e.preventDefault();
-      const kr = await sendKey('FIELD_EXIT');
-      if (kr.cursor_row !== undefined) setSyncedCursor({ row: kr.cursor_row, col: kr.cursor_col! });
+      setSyncedCursor(null);
+      sendKey('FIELD_EXIT');
       return;
     }
 
@@ -614,6 +701,8 @@ export function GreenScreenTerminal({
       e.preventDefault();
       // Self-check any declared MOD10/MOD11 fields before submitting
       if (!runSelfCheck()) return;
+      // Lock keyboard instantly so X II badge appears without waiting for proxy
+      setOptimisticLock(true);
       const kr = await sendKey(e.key);
       if (kr.cursor_row !== undefined) setSyncedCursor({ row: kr.cursor_row, col: kr.cursor_col! });
       return;
@@ -625,6 +714,52 @@ export function GreenScreenTerminal({
       const k = keyMap[e.key];
       const isSubmit = k === 'ENTER' || k === 'PAGEUP' || k === 'PAGEDOWN';
       if (isSubmit && !runSelfCheck()) return;
+
+      // Arrow keys: optimistically predict the new cursor position locally so
+      // the visual cursor moves immediately, matching typing's responsiveness.
+      // Local prediction mirrors the proxy's simple grid-wrap arithmetic —
+      // col±1 with column/row wrapping. The subsequent proxy 'cursor' push
+      // message updates rawScreenData but is shadowed by syncedCursor here,
+      // which is fine because our prediction matches the proxy's result.
+      if (k === 'UP' || k === 'DOWN' || k === 'LEFT' || k === 'RIGHT') {
+        const termRows = screenData?.rows || profile.defaultRows;
+        const termColsLocal = screenData?.cols || profile.defaultCols;
+        const curRow = syncedCursor?.row ?? screenData?.cursor_row ?? 0;
+        const curCol = syncedCursor?.col ?? screenData?.cursor_col ?? 0;
+        let newRow = curRow;
+        let newCol = curCol;
+        if (k === 'LEFT') {
+          newCol = curCol - 1;
+          if (newCol < 0) { newCol = termColsLocal - 1; newRow = (curRow - 1 + termRows) % termRows; }
+        } else if (k === 'RIGHT') {
+          newCol = curCol + 1;
+          if (newCol >= termColsLocal) { newCol = 0; newRow = (curRow + 1) % termRows; }
+        } else if (k === 'UP') {
+          newRow = (curRow - 1 + termRows) % termRows;
+        } else {
+          newRow = (curRow + 1) % termRows;
+        }
+        setSyncedCursor({ row: newRow, col: newCol });
+        sendKey(k);
+        return;
+      }
+
+      // Non-arrow cursor movers (TAB, HOME, END, BACKSPACE, DELETE, INSERT):
+      // outcome depends on field layout / host state, so local prediction
+      // isn't trivial. Clear syncedCursor and let the proxy's pushed update
+      // (via adapter.onScreen → rawScreenData) position the cursor.
+      const isOtherMovement = k === 'TAB' || k === 'HOME' || k === 'END'
+        || k === 'BACKSPACE' || k === 'DELETE' || k === 'INSERT';
+      if (isOtherMovement) {
+        setSyncedCursor(null);
+        sendKey(k);
+        return;
+      }
+
+      // AID/submit keys (ENTER, PAGEUP, PAGEDOWN) — await so self-check errors
+      // can abort before the screen transitions.
+      // Lock keyboard instantly so X II badge appears without waiting for proxy.
+      setOptimisticLock(true);
       const kr = await sendKey(k);
       if (kr.cursor_row !== undefined) setSyncedCursor({ row: kr.cursor_row, col: kr.cursor_col! });
     }
@@ -690,6 +825,143 @@ export function GreenScreenTerminal({
     return { row: cursorRow, col: cursorCol };
   };
 
+  // --- WDSF popup windows + heuristic plain-char popup detection ---
+  // IBM i UIM popups (DSPMSG help, CRTLIB prompter, Exit Interactive SQL,
+  // etc.) arrive in two flavors:
+  //   (a) CREATE_WINDOW structured fields — proxy records metadata in
+  //       screenData.windows. Easy: read the metadata.
+  //   (b) Plain WRITE_TO_DISPLAY with literal `.` / `:` border characters
+  //       painted into the buffer. No metadata. We detect these heuristically
+  //       by scanning for rectangular patterns of `.` on top/bottom rows and
+  //       `:` on left/right columns.
+  // In either case we produce a unified window list, blank the underlying
+  // ASCII border cells in renderRowWithFields, and draw styled .gs-window
+  // overlays (Mocha/ACS-style rounded accent frame with title/footer).
+  const detectedWindows = useMemo(() => {
+    const wdsf = (screenData as any)?.windows as Array<{ row: number; col: number; height: number; width: number; title?: string; footer?: string }> | undefined;
+    if (wdsf && wdsf.length > 0) return wdsf;
+    const content = screenData?.content;
+    const cols = screenData?.cols || profile.defaultCols;
+    const termRows = screenData?.rows || profile.defaultRows;
+    if (!content) return [];
+    const lines = content.split('\n');
+    const rowAt = (r: number) => (lines[r] || '').padEnd(cols, ' ');
+    const DOT = '.';
+    const COL = ':';
+    // Heuristic: a run of 5+ consecutive `.` chars at the same col range on
+    // two distinct rows, with `:` at both edges on every row between them.
+    // MIN_WIDTH 5 rules out dotted separators ("........") used as filler in
+    // label fields like "Option . . . . . . . . 1". MIN_HEIGHT 2 rules out
+    // single-line patterns. We only keep the first rectangle that starts on
+    // each row to avoid pathological nesting.
+    const MIN_WIDTH = 20; // popups are typically wide; avoids matching "Selection . . . . . . ."
+    const found: Array<{ row: number; col: number; height: number; width: number; title?: string; footer?: string }> = [];
+    const claimedTop = new Set<number>();
+    for (let rTop = 0; rTop < termRows - 2; rTop++) {
+      if (claimedTop.has(rTop)) continue;
+      const topLine = rowAt(rTop);
+      // Find runs of dots (length >= MIN_WIDTH)
+      let c = 0;
+      while (c < cols) {
+        if (topLine[c] !== DOT) { c++; continue; }
+        let end = c;
+        while (end < cols && topLine[end] === DOT) end++;
+        const runLen = end - c;
+        if (runLen >= MIN_WIDTH) {
+          const startCol = c;
+          const endCol = end - 1;
+          // Scan downward: need `:` at startCol and endCol on subsequent rows
+          // until we hit a row that doesn't match (bottom edge candidate).
+          let r = rTop + 1;
+          while (r < termRows) {
+            const line = rowAt(r);
+            if (line[startCol] !== COL || line[endCol] !== COL) break;
+            r++;
+          }
+          const lastMidRow = r - 1; // last row with `:` at both edges
+          const heightMid = lastMidRow - rTop; // rows between top edge and break
+          if (heightMid < 2) { c = end; continue; }
+          // Bottom-edge detection. Two shapes observed in IBM i:
+          //   (a) The `:` pattern terminates, and row lastMidRow+1 is a
+          //       horizontal `.` run (no corner chars). Top was pure dots;
+          //       bottom is pure dots.
+          //   (b) The LAST mid row itself is the bottom edge: `:` at
+          //       startCol, dots in between, `:` at endCol. No separate
+          //       bottom row.
+          let bottomRow = -1;
+          let title: string | undefined;
+          let footer: string | undefined;
+          // Try (b) first: is lastMidRow actually `:...:`?
+          {
+            const line = rowAt(lastMidRow);
+            let dots = 0;
+            for (let cc = startCol + 1; cc < endCol; cc++) if (line[cc] === DOT) dots++;
+            const innerLen = Math.max(1, endCol - startCol - 1);
+            if (dots >= innerLen * 0.8) {
+              bottomRow = lastMidRow;
+            }
+          }
+          // Try (a): row below lastMidRow is a `.` row
+          if (bottomRow < 0 && lastMidRow + 1 < termRows) {
+            const line = rowAt(lastMidRow + 1);
+            let dots = 0;
+            for (let cc = startCol; cc <= endCol; cc++) if (line[cc] === DOT) dots++;
+            const span = Math.max(1, endCol - startCol + 1);
+            if (dots >= span * 0.8) {
+              bottomRow = lastMidRow + 1;
+            }
+          }
+          if (bottomRow < 0) { c = end; continue; }
+          // Extract title/footer: any non-dot non-space text on the border
+          // rows. E.g. " Option - Help " embedded in the top row dots.
+          const topInner = topLine.substring(startCol + 1, endCol)
+            .replace(/\./g, ' ').trim();
+          if (topInner.length > 0) title = topInner;
+          const botLine = rowAt(bottomRow);
+          const botInner = botLine.substring(startCol + 1, endCol)
+            .replace(/\./g, ' ').trim();
+          if (botInner.length > 0) footer = botInner;
+          found.push({
+            row: rTop,
+            col: startCol,
+            height: bottomRow - rTop - 1,
+            width: endCol - startCol - 1,
+            title,
+            footer,
+          });
+          claimedTop.add(rTop);
+          claimedTop.add(bottomRow);
+          break;
+        }
+        c = end;
+      }
+    }
+    return found;
+  }, [screenData, profile.defaultCols, profile.defaultRows]);
+
+  const windowBorderAddrs = useMemo(() => {
+    const set = new Set<number>();
+    if (!detectedWindows || detectedWindows.length === 0) return set;
+    const cols = screenData?.cols || profile.defaultCols;
+    for (const w of detectedWindows) {
+      const topRow = w.row;
+      const botRow = w.row + w.height + 1;
+      const leftCol = w.col;
+      const rightCol = w.col + w.width + 1;
+      // Top + bottom edges (inclusive of corners)
+      for (let c = leftCol; c <= rightCol; c++) {
+        set.add(topRow * cols + c);
+        set.add(botRow * cols + c);
+      }
+      // Left + right edges
+      for (let r = topRow + 1; r < botRow; r++) {
+        set.add(r * cols + leftCol);
+        set.add(r * cols + rightCol);
+      }
+    }
+    return set;
+  }, [detectedWindows, screenData?.cols, profile.defaultCols]);
+
   // --- Rendering helpers ---
   const renderTextWithUnderlines = useCallback((text: string, keyPrefix: string): React.ReactNode => {
     const underscoreRegex = /_{2,}/g;
@@ -700,7 +972,7 @@ export function GreenScreenTerminal({
     while ((match = underscoreRegex.exec(text)) !== null) {
       if (match.index > lastIndex) segments.push(<span key={`${keyPrefix}-t-${segmentIndex}`}>{text.substring(lastIndex, match.index)}</span>);
       const count = match[0].length;
-      segments.push(<span key={`${keyPrefix}-u-${segmentIndex}`} style={{ borderBottom: '1px solid var(--gs-green, #10b981)', display: 'inline-block', width: `${count}ch` }}>{' '.repeat(count)}</span>);
+      segments.push(<span key={`${keyPrefix}-u-${segmentIndex}`} style={{ borderBottom: '1px solid var(--gs-green, #a6e3a1)', display: 'inline-block', width: `${count}ch` }}>{' '.repeat(count)}</span>);
       lastIndex = match.index + match[0].length;
       segmentIndex++;
     }
@@ -715,13 +987,35 @@ export function GreenScreenTerminal({
     cursorRow: number,
     cursorCol: number,
   ): React.ReactNode => {
-    const inputFields = fields.filter(f => f.row === rowIndex && f.is_input);
+    const cols = screenData?.cols || profile.defaultCols;
+    // Blank out WDSF window border cells — the host writes literal `.` and
+    // `:` characters into the buffer for the popup border. We render a real
+    // styled frame overlay (see .gs-window below) so the ASCII cells should
+    // appear blank. Title/footer text lives on these rows too but is also
+    // re-rendered via .gs-window-title / -footer overlays, so blank-all is
+    // safe.
+    if (windowBorderAddrs.size > 0) {
+      const chars = line.split('');
+      for (let c = 0; c < chars.length; c++) {
+        if (windowBorderAddrs.has(rowIndex * cols + c)) chars[c] = ' ';
+      }
+      line = chars.join('');
+    }
+    // Multi-row input fields (IBM i command lines often span 2-3 rows) need
+    // their underline rendered on every row they span, not just the starting
+    // row. Build virtual field slices with row/col/length adjusted to the
+    // current row's visible portion of each field.
+    const inputFields: Field[] = [];
+    for (const f of fields) {
+      if (!f.is_input) continue;
+      const slice = fieldSliceForRow(f, rowIndex, cols);
+      if (!slice) continue;
+      inputFields.push({ ...f, row: rowIndex, col: slice.col, length: slice.length });
+    }
     const highlightedFields = fields.filter(f => f.row === rowIndex && f.is_protected && f.is_highlighted);
     const reverseFields = fields.filter(f => f.row === rowIndex && f.is_protected && f.is_reverse);
     const colorFields = fields.filter(f => f.row === rowIndex && f.is_protected && (f as any).color && !f.is_highlighted && !f.is_reverse);
     const allRowFields = [...inputFields, ...highlightedFields, ...reverseFields, ...colorFields];
-
-    const cols = screenData?.cols || profile.defaultCols;
     const extAttrs = (screenData as any)?.ext_attrs as Record<number, { color?: number; highlight?: number; char_set?: number }> | undefined;
     const dbcsCont = (screenData as any)?.dbcs_cont as number[] | undefined;
     const dbcsContSet = dbcsCont && dbcsCont.length > 0 ? new Set(dbcsCont) : null;
@@ -908,13 +1202,13 @@ export function GreenScreenTerminal({
       return (
         <div style={{ width: `${screenData?.cols || profile.defaultCols}ch`, height: `${(screenData?.rows || profile.defaultRows) * 21}px`, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
           <div style={{ textAlign: 'center' }}>
-            <div style={{ color: '#808080', marginBottom: '12px' }}><TerminalIcon size={40} /></div>
-            <p style={{ fontFamily: 'var(--gs-font)', fontSize: '12px', color: connStatus?.status === 'connecting' ? '#f59e0b' : connStatus?.status === 'loading' ? '#94a3b8' : '#808080' }}>
+            <div style={{ color: 'var(--gs-muted, #6c7086)', marginBottom: '12px' }}><TerminalIcon size={40} /></div>
+            <p style={{ fontFamily: 'var(--gs-font)', fontSize: '12px', color: connStatus?.status === 'connecting' ? 'var(--gs-yellow, #f9e2af)' : connStatus?.status === 'loading' ? 'var(--gs-muted, #6c7086)' : 'var(--gs-muted, #6c7086)' }}>
               {connStatus?.connected ? 'Waiting for screen data...' : connStatus?.status === 'connecting' ? 'Connecting...' : connStatus?.status === 'loading' ? 'Loading...' : 'Not connected'}
             </p>
             {!connStatus?.connected && isUsingDefaultAdapter && (
-              <p style={{ fontFamily: 'var(--gs-font)', fontSize: '11px', color: '#606060', marginTop: '8px' }}>
-                Start the proxy: <code style={{ color: '#10b981' }}>npx green-screen-proxy</code>
+              <p style={{ fontFamily: 'var(--gs-font)', fontSize: '11px', color: 'var(--gs-muted, #6c7086)', marginTop: '8px' }}>
+                Start the proxy: <code style={{ color: 'var(--gs-accent, #cba6f7)' }}>npx green-screen-proxy</code>
               </p>
             )}
           </div>
@@ -940,11 +1234,21 @@ export function GreenScreenTerminal({
     // (ACS, Mocha) show the cursor in password (NON_DISPLAY) fields too —
     // that's the only feedback that a keypress was registered, since the
     // typed characters stay invisible.
-    const cursorInInputField = hasCursor && fields.some(f =>
-      f.is_input &&
-      f.row === cursor.row &&
-      cursor.col >= f.col && cursor.col < f.col + f.length
-    );
+    const cursorInInputField = hasCursor && fields.some(f => {
+      if (!f.is_input) return false;
+      // Handle multi-row wrapping input fields (e.g. IBM i command lines).
+      const slice = fieldSliceForRow(f, cursor.row, cols);
+      // Allow cursor at the trailing "end-marker" position (col === slice.col
+      // + slice.length) — after typing into a single-char field (e.g. the
+      // Option input on the Exit Interactive SQL UIM popup), the proxy
+      // advances cursor one past the last editable cell. Mocha and ACS still
+      // render the cursor there. Without this, the cursor vanishes and users
+      // can't tell they're positioned in the field.
+      return !!slice && cursor.col >= slice.col && cursor.col <= slice.col + slice.length;
+    });
+
+    const ROW_H = 21; // matches ROW_HEIGHT above; used for window overlay positioning
+    const screenWindows = detectedWindows;
 
     return (
       <div style={{ fontFamily: 'var(--gs-font)', fontSize: '13px', position: 'relative', width: `${cols}ch` }}>
@@ -966,11 +1270,38 @@ export function GreenScreenTerminal({
                 ? headerSegments.map((seg, i) => <span key={i} className={seg.colorClass}>{seg.text}</span>)
                 : renderRowWithFields(displayLine, index, fields, cursor.row, cursor.col)}
               {cursorInInputField && index === cursor.row && (
-                <span className="gs-cursor" style={{ position: 'absolute', left: `${cursor.col}ch`, width: '1ch', height: `${ROW_HEIGHT}px`, top: 0, pointerEvents: 'none' }} />
+                <span className="gs-cursor" style={{ position: 'absolute', left: `${cursor.col}ch`, width: screenData?.insert_mode ? '1ch' : '2px', height: `${ROW_HEIGHT}px`, top: 0, pointerEvents: 'none' }} />
               )}
             </div>
           );
         })}
+        {/* WDSF popup window frames (styled overlays replacing the ASCII
+         * border cells). Each window is positioned absolutely over its
+         * border cells and sized to cover the full window rectangle. Title
+         * and footer are rendered as small centered labels on the top/bottom
+         * edges. pointer-events: none so clicks pass through to the content
+         * (input fields inside the window remain clickable). */}
+        {screenWindows && screenWindows.map((w, wi) => (
+          <div
+            key={`gs-window-${wi}`}
+            className="gs-window"
+            style={{
+              position: 'absolute',
+              left: `${w.col}ch`,
+              top: `${w.row * ROW_H}px`,
+              width: `${w.width + 2}ch`,
+              height: `${(w.height + 2) * ROW_H}px`,
+              pointerEvents: 'none',
+            }}
+          >
+            {w.title && (
+              <span className="gs-window-title">{w.title}</span>
+            )}
+            {w.footer && (
+              <span className="gs-window-footer">{w.footer}</span>
+            )}
+          </div>
+        ))}
         {validationError && (
           <div
             role="alert"
@@ -992,7 +1323,7 @@ export function GreenScreenTerminal({
           </div>
         )}
         {screenData.cursor_row !== undefined && screenData.cursor_col !== undefined && (
-          <span style={{ position: 'absolute', bottom: 0, right: 0, fontFamily: 'var(--gs-font)', fontSize: '10px', color: 'var(--gs-green, #10b981)', pointerEvents: 'none', opacity: 0.6 }}>
+          <span style={{ position: 'absolute', bottom: 0, right: 0, fontFamily: 'var(--gs-font)', fontSize: '10px', color: 'var(--gs-muted, #6c7086)', pointerEvents: 'none', opacity: 0.6 }}>
             {String(screenData.cursor_row + 1).padStart(2, '0')}/{String(screenData.cursor_col + 1).padStart(3, '0')}
           </span>
         )}
@@ -1001,21 +1332,30 @@ export function GreenScreenTerminal({
   };
 
   const handleReconnect = async () => {
-    setAutoReconnectAttempt(0);
-    setIsAutoReconnecting(false);
-    if (reconnectTimeoutRef.current) { clearTimeout(reconnectTimeoutRef.current); reconnectTimeoutRef.current = null; }
+    resetAutoReconnect();
     await reconnect();
   };
 
   const getStatusColor = (status?: string) => {
     switch (status) {
-      case 'authenticated': return 'var(--gs-green, #10b981)';
-      case 'connected': return '#64748b';
-      case 'connecting': return '#64748b';
-      case 'error': return '#EF4444';
-      default: return '#64748b';
+      case 'authenticated': return 'var(--gs-green, #a6e3a1)';
+      case 'connected': return 'var(--gs-muted, #6c7086)';
+      case 'connecting': return 'var(--gs-muted, #6c7086)';
+      case 'error': return 'var(--gs-red, #f38ba8)';
+      default: return 'var(--gs-muted, #6c7086)';
     }
   };
+
+  // --- Disconnect handler ---
+  const [disconnecting, setDisconnecting] = useState(false);
+  const handleDisconnect = useCallback(async () => {
+    setDisconnecting(true);
+    try {
+      await adapter.disconnect();
+    } catch { /* ignore */ }
+    setDisconnecting(false);
+    onDisconnect?.();
+  }, [adapter, onDisconnect]);
 
   // Send a key from the shortcuts panel. Mirrors the submit-key self-check
   // behaviour in handleKeyDown so clicked shortcuts behave like keystrokes.
@@ -1025,31 +1365,50 @@ export function GreenScreenTerminal({
     if (isSubmit && !runSelfCheck()) return;
     setIsFocused(true);
     inputRef.current?.focus();
+    // Clear optimistic cursor and fire-and-forget for non-submit keys — the
+    // proxy's pushed cursor/screen update flows through adapter.onScreen into
+    // rawScreenData. For submit keys (ENTER/PageUp/PageDown/F-keys) the screen
+    // transition fully clears state anyway.
+    if (!isSubmit) {
+      setSyncedCursor(null);
+      sendKey(key);
+      return;
+    }
+    setOptimisticLock(true);
     const kr = await sendKey(key);
     if (kr.cursor_row !== undefined) setSyncedCursor({ row: kr.cursor_row, col: kr.cursor_col! });
   }, [readOnly, runSelfCheck, sendKey]);
 
   return (
-    <div ref={containerRef} className={`gs-terminal ${isFocused ? 'gs-terminal-focused' : ''} ${className || ''}`} style={style}>
-      {showHeader && (
+    <div ref={containerRef} className={`gs-terminal gs-theme-${theme} ${isFocused ? 'gs-terminal-focused' : ''} ${className || ''}`} style={style}>
+      {/* Header: custom header prop takes precedence over showHeader/embedded */}
+      {header !== undefined ? (
+        header === false ? null :
+        typeof header === 'function' ? header({
+          connectionStatus: connStatus,
+          keyboardLocked: !!screenData?.keyboard_locked || optimisticLock,
+          insertMode: !!screenData?.insert_mode,
+          isFocused,
+          reconnect: handleReconnect,
+          reconnecting: reconnecting || isAutoReconnecting,
+        }) :
+        header
+      ) : showHeader ? (
         <div className="gs-header">
           {embedded ? (
             <>
               <span className="gs-header-left">
-                <TerminalIcon size={14} />
-                <span>TERMINAL</span>
-                {isFocused && <span className="gs-badge-focused">FOCUSED</span>}
-                {screenData?.timestamp && <span className="gs-timestamp">{new Date(screenData.timestamp).toLocaleTimeString()}</span>}
-                {showShortcutsButton && !readOnly && isFocused && <button onClick={(e) => { e.stopPropagation(); setShowShortcuts(s => !s); }} className="gs-btn-icon" title="Keyboard shortcuts"><KeyboardIcon size={12} /></button>}
-                <span className="gs-hint">{readOnly ? 'Read-only' : isFocused ? 'ESC to exit focus' : 'Click to control'}</span>
-                {screenData?.keyboard_locked && <span className="gs-badge-lock">X II</span>}
+                {showShortcutsButton && !readOnly && isFocused && <button onClick={(e) => { e.stopPropagation(); setShowShortcuts(s => !s); }} className="gs-btn-icon" title="Keyboard shortcuts"><KeyboardIcon size={16} /></button>}
+                {(screenData?.keyboard_locked || optimisticLock) && <span className="gs-badge-lock">X II</span>}
                 {screenData?.insert_mode && <span className="gs-badge-ins">INS</span>}
               </span>
+              <span className="gs-header-title">Terminal</span>
               <div className="gs-header-right">
-                {connStatus?.status && connStatus.status !== 'loading' && <KeyIcon size={12} style={{ color: getStatusColor(connStatus.status) }} />}
-                {connStatus && connStatus.status !== 'loading' && (connStatus.connected
-                  ? <WifiIcon size={12} style={{ color: 'var(--gs-green, #10b981)' }} />
-                  : <WifiOffIcon size={12} style={{ color: '#FF6B00' }} />)}
+                {connStatus && connStatus.status !== 'loading' && (
+                  connStatus.connected
+                    ? <WifiIcon size={12} className="gs-connection-icon gs-connection-icon-connected" />
+                    : <WifiOffIcon size={12} className="gs-connection-icon gs-connection-icon-disconnected" />
+                )}
                 {statusActions}
                 {onMinimize && <button onClick={(e) => { e.stopPropagation(); onMinimize(); }} className="gs-btn-icon" title="Minimize terminal"><MinimizeIcon /></button>}
                 {headerRight}
@@ -1058,43 +1417,58 @@ export function GreenScreenTerminal({
           ) : (
             <>
               <span className="gs-header-left">
-                <TerminalIcon size={14} />
-                <span>{profile.headerLabel}</span>
-                {isFocused && <span className="gs-badge-focused">FOCUSED</span>}
-                {screenData?.timestamp && <span className="gs-timestamp">{new Date(screenData.timestamp).toLocaleTimeString()}</span>}
-                {showShortcutsButton && !readOnly && isFocused && <button onClick={(e) => { e.stopPropagation(); setShowShortcuts(s => !s); }} className="gs-btn-icon" title="Keyboard shortcuts"><KeyboardIcon size={12} /></button>}
-                <span className="gs-hint">{readOnly ? 'Read-only mode' : isFocused ? 'ESC to exit focus' : 'Click terminal to control'}</span>
-                {screenData?.keyboard_locked && <span className="gs-badge-lock">X II</span>}
+                {showShortcutsButton && !readOnly && isFocused && <button onClick={(e) => { e.stopPropagation(); setShowShortcuts(s => !s); }} className="gs-btn-icon" title="Keyboard shortcuts"><KeyboardIcon size={16} /></button>}
+                {(screenData?.keyboard_locked || optimisticLock) && <span className="gs-badge-lock">X II</span>}
                 {screenData?.insert_mode && <span className="gs-badge-ins">INS</span>}
+              </span>
+              <span className="gs-header-title">
+                {profile.headerLabel.replace(' TERMINAL', '')}
               </span>
               <div className="gs-header-right">
                 {connStatus && connStatus.status !== 'loading' && (
-                  <div className="gs-status-group">
-                    {connStatus.connected ? (
-                      <>
-                        <WifiIcon size={12} style={{ color: 'var(--gs-green, #10b981)' }} />
-                        <span className="gs-host">{connStatus.host}</span>
-                      </>
-                    ) : (
-                      <>
-                        <WifiOffIcon size={12} style={{ color: '#FF6B00' }} />
-                        <span className="gs-disconnected-text">
-                          {isAutoReconnecting || reconnecting
-                            ? `RECONNECTING${autoReconnectAttempt > 0 ? ` (${autoReconnectAttempt}/${maxAttempts})` : '...'}`
-                            : autoReconnectAttempt >= maxAttempts ? 'DISCONNECTED (auto-retry exhausted)' : 'DISCONNECTED'}
-                        </span>
-                        <button onClick={handleReconnect} disabled={reconnecting || isAutoReconnecting} className="gs-btn-icon" title="Reconnect">
-                          <RefreshIcon size={12} className={reconnecting || isAutoReconnecting ? 'gs-spin' : ''} />
-                        </button>
-                      </>
-                    )}
-                  </div>
-                )}
-                {connStatus?.status && connStatus.status !== 'loading' && (
-                  <div className="gs-status-group">
-                    <KeyIcon size={12} style={{ color: getStatusColor(connStatus.status) }} />
-                    {connStatus.username && <span className="gs-host">{connStatus.username}</span>}
-                  </div>
+                  connStatus.connected ? (
+                    <div className="gs-status-group">
+                      <WifiIcon size={12} className="gs-connection-icon gs-connection-icon-connected" />
+                      <span className="gs-host">{connStatus.host}</span>
+                      {connStatus.username && (
+                        <>
+                          <KeyIcon size={11} style={{ color: getStatusColor(connStatus.status) }} />
+                          <span className="gs-host">{connStatus.username}</span>
+                        </>
+                      )}
+                      {connStatus.status !== 'authenticated' && (
+                        <RefreshIcon size={12} className="gs-spin" />
+                      )}
+                      <button
+                        onClick={handleDisconnect}
+                        disabled={disconnecting}
+                        className="gs-disconnect-btn"
+                        title="Disconnect terminal session"
+                      >
+                        <UnplugIcon size={12} />
+                        <span>Disconnect</span>
+                      </button>
+                    </div>
+                  ) : (
+                    <div className="gs-status-group">
+                      <WifiOffIcon size={12} className="gs-connection-icon gs-connection-icon-disconnected" />
+                      {connStatus.host && <span className="gs-host">{connStatus.host}</span>}
+                      {connStatus.username && (
+                        <>
+                          <KeyIcon size={11} style={{ color: 'var(--gs-muted)' }} />
+                          <span className="gs-host">{connStatus.username}</span>
+                        </>
+                      )}
+                      <span className="gs-disconnected-text">
+                        {isAutoReconnecting || reconnecting
+                          ? `Reconnecting${autoReconnectAttempt > 0 ? ` (${autoReconnectAttempt}/${maxAttempts})` : '...'}`
+                          : 'Disconnected'}
+                      </span>
+                      <button onClick={handleReconnect} disabled={reconnecting || isAutoReconnecting} className="gs-btn-icon" title="Reconnect">
+                        <RefreshIcon size={12} className={reconnecting || isAutoReconnecting ? 'gs-spin' : ''} />
+                      </button>
+                    </div>
+                  )
                 )}
                 {statusActions}
                 {headerRight}
@@ -1102,11 +1476,11 @@ export function GreenScreenTerminal({
             </>
           )}
         </div>
-      )}
+      ) : null}
 
       <div className="gs-body">
         <div ref={terminalRef} onClick={handleTerminalClick} className={`gs-screen ${embedded ? 'gs-screen-embedded' : ''}`}
-          style={!embedded ? { width: `calc(${screenData?.cols || profile.defaultCols}ch + 24px)`, fontSize: (screenData?.cols ?? profile.defaultCols) > 80 ? '11px' : '13px', fontFamily: 'var(--gs-font)' } : undefined}>
+          style={!embedded ? { width: `calc(${screenData?.cols || profile.defaultCols}ch + 32px)`, fontSize: (screenData?.cols ?? profile.defaultCols) > 80 ? '11px' : '13px', fontFamily: 'var(--gs-font)' } : undefined}>
           {screenError != null && (
             <div className="gs-error-banner">
               <AlertTriangleIcon size={14} />
@@ -1116,10 +1490,25 @@ export function GreenScreenTerminal({
           <div ref={screenContentRef} className="gs-screen-content">{renderScreen()}</div>
           {overlay}
           {showShortcuts && (
-            <div className="gs-shortcuts-panel">
-              <div className="gs-shortcuts-header">
+            <div
+              ref={shortcutsPanelRef}
+              className="gs-shortcuts-panel"
+              style={shortcutsPos
+                ? { position: 'fixed', left: `${shortcutsPos.x}px`, top: `${shortcutsPos.y}px`, right: 'auto', bottom: 'auto' }
+                : { position: 'fixed', visibility: 'hidden' }}
+              onClick={(e) => e.stopPropagation()}
+            >
+              <div
+                className="gs-shortcuts-header"
+                onMouseDown={startShortcutsDrag}
+                style={{ cursor: isDraggingShortcuts ? 'grabbing' : 'grab', userSelect: 'none' }}
+              >
                 <span>Keyboard Shortcuts</span>
-                <button className="gs-btn-icon" onClick={() => setShowShortcuts(false)}>&times;</button>
+                <button
+                  className="gs-btn-icon"
+                  onMouseDown={(e) => e.stopPropagation()}
+                  onClick={() => setShowShortcuts(false)}
+                >&times;</button>
               </div>
               <div className="gs-shortcuts-actions">
                 {([

--- a/packages/react/src/components/Icons.tsx
+++ b/packages/react/src/components/Icons.tsx
@@ -57,3 +57,15 @@ export const MinimizeIcon = () => (
     <path d="M4 14h6v6M3 21l7-7M20 10h-6V4M21 3l-7 7" />
   </svg>
 );
+
+export const UnplugIcon = ({ size = 14 }: { size?: number }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M19 5l3-3" /><path d="M2 22l3-3" /><path d="M6.3 20.3a2.4 2.4 0 0 0 3.4 0L12 18l-6-6-2.3 2.3a2.4 2.4 0 0 0 0 3.4Z" /><path d="M7.5 13.5 10 11" /><path d="M10.5 16.5 13 14" /><path d="m12 6 6 6 2.3-2.3a2.4 2.4 0 0 0 0-3.4l-2.6-2.6a2.4 2.4 0 0 0-3.4 0Z" />
+  </svg>
+);
+
+export const PlugIcon = ({ size = 14 }: { size?: number }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M12 22v-5" /><path d="M9 8V2" /><path d="M15 8V2" /><path d="M18 8v5a6 6 0 0 1-6 6v0a6 6 0 0 1-6-6V8Z" />
+  </svg>
+);

--- a/packages/react/src/components/InlineSignIn.tsx
+++ b/packages/react/src/components/InlineSignIn.tsx
@@ -88,6 +88,10 @@ export function InlineSignIn({ defaultProtocol, loading: externalLoading, error,
 
   const termTypeOptions = TERMINAL_TYPE_OPTIONS[selectedProtocol];
   const [submitted, setSubmitted] = useState(false);
+  // Collapsible block that hides Screen Size + Username + Password behind
+  // a "Show all params" toggle. Keeps the initial form minimal (just Host
+  // / Port / Protocol / Connect), users can reveal the rest when needed.
+  const [showAllParams, setShowAllParams] = useState(false);
 
   const loading = externalLoading || submitted;
 
@@ -107,9 +111,10 @@ export function InlineSignIn({ defaultProtocol, loading: externalLoading, error,
   const inputStyle: React.CSSProperties = {
     width: '100%',
     padding: '6px 8px',
-    backgroundColor: 'rgba(16, 185, 129, 0.05)',
-    border: '1px solid var(--gs-card-border, #1e293b)',
-    color: 'var(--gs-green, #10b981)',
+    backgroundColor: 'rgba(203, 166, 247, 0.05)',
+    border: '1px solid var(--gs-card-border, #313244)',
+    borderRadius: '6px',
+    color: 'var(--gs-white, #cdd6f4)',
     fontFamily: 'var(--gs-font)',
     fontSize: '13px',
     outline: 'none',
@@ -162,27 +167,49 @@ export function InlineSignIn({ defaultProtocol, loading: externalLoading, error,
         </select>
       </div>
 
-      {termTypeOptions && termTypeOptions.length > 1 && (
-        <div>
-          <label style={labelStyle}>Screen Size</label>
-          <select style={{ ...inputStyle, appearance: 'none' }} value={terminalType || termTypeOptions[0].value} onChange={e => setTerminalType(e.target.value)}>
-            {termTypeOptions.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
-          </select>
-        </div>
+      <button
+        type="button"
+        onClick={() => setShowAllParams(s => !s)}
+        aria-expanded={showAllParams}
+        className="gs-signin-toggle"
+      >
+        <span>{showAllParams ? 'Hide all params' : 'Show all params'}</span>
+        <svg
+          width="12" height="12" viewBox="0 0 24 24"
+          fill="none" stroke="currentColor" strokeWidth="2.5"
+          strokeLinecap="round" strokeLinejoin="round"
+          style={{ transform: showAllParams ? 'rotate(180deg)' : 'none', transition: 'transform 0.18s ease' }}
+          aria-hidden="true"
+        >
+          <polyline points="6 9 12 15 18 9" />
+        </svg>
+      </button>
+
+      {showAllParams && (
+        <>
+          {termTypeOptions && termTypeOptions.length > 1 && (
+            <div>
+              <label style={labelStyle}>Screen Size</label>
+              <select style={{ ...inputStyle, appearance: 'none' }} value={terminalType || termTypeOptions[0].value} onChange={e => setTerminalType(e.target.value)}>
+                {termTypeOptions.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
+              </select>
+            </div>
+          )}
+
+          <div>
+            <label style={labelStyle}>Username</label>
+            <input style={inputStyle} value={username} onChange={e => setUsername(e.target.value)} autoComplete="username" />
+          </div>
+
+          <div>
+            <label style={labelStyle}>Password</label>
+            <input style={inputStyle} type="password" value={password} onChange={e => setPassword(e.target.value)} autoComplete="current-password" />
+          </div>
+        </>
       )}
 
-      <div>
-        <label style={labelStyle}>Username</label>
-        <input style={inputStyle} value={username} onChange={e => setUsername(e.target.value)} autoComplete="username" />
-      </div>
-
-      <div>
-        <label style={labelStyle}>Password</label>
-        <input style={inputStyle} type="password" value={password} onChange={e => setPassword(e.target.value)} autoComplete="current-password" />
-      </div>
-
       {error && (
-        <div style={{ color: '#FF6B00', fontSize: '11px', fontFamily: 'var(--gs-font)', display: 'flex', alignItems: 'center', gap: '6px' }}>
+        <div style={{ color: 'var(--gs-red, #f38ba8)', fontSize: '11px', fontFamily: 'var(--gs-font)', display: 'flex', alignItems: 'center', gap: '6px' }}>
           <AlertTriangleIcon size={12} />
           <span>{error}</span>
         </div>

--- a/packages/react/src/components/TerminalBootLoader.tsx
+++ b/packages/react/src/components/TerminalBootLoader.tsx
@@ -61,8 +61,8 @@ export function TerminalBootLoader({
             fontFamily: 'var(--gs-font)',
             fontSize: '1.5rem',
             letterSpacing: '0.1em',
-            color: 'var(--gs-green, #10b981)',
-            textShadow: '0 0 12px rgba(16, 185, 129, 0.4)',
+            color: 'var(--gs-accent, #cba6f7)',
+            textShadow: '0 0 20px rgba(203, 166, 247, 0.15)',
             margin: 0,
           }}
         >

--- a/packages/react/src/hooks/useAutoReconnect.ts
+++ b/packages/react/src/hooks/useAutoReconnect.ts
@@ -1,0 +1,85 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+
+export interface UseAutoReconnectOptions {
+  /** Whether auto-reconnect is enabled (default true) */
+  enabled?: boolean;
+  /** Maximum number of reconnect attempts (default 5) */
+  maxAttempts?: number;
+  /** Callback for notifications */
+  onNotification?: (message: string, type: 'info' | 'error') => void;
+}
+
+export interface UseAutoReconnectResult {
+  /** Current reconnect attempt number */
+  attempt: number;
+  /** Whether a reconnect is currently in progress */
+  isReconnecting: boolean;
+  /** Reset the reconnect state (e.g. for manual reconnect) */
+  reset: () => void;
+}
+
+/**
+ * Hook for auto-reconnecting to a terminal backend with exponential backoff.
+ *
+ * @param connected - Whether the terminal is currently connected
+ * @param reconnecting - Whether a reconnect operation is in progress (from useTerminalConnection)
+ * @param reconnect - Function to trigger a reconnect
+ * @param options - Configuration options
+ */
+export function useAutoReconnect(
+  connected: boolean,
+  reconnecting: boolean,
+  reconnect: () => Promise<{ success: boolean } | undefined>,
+  options: UseAutoReconnectOptions = {},
+): UseAutoReconnectResult {
+  const {
+    enabled = true,
+    maxAttempts = 5,
+    onNotification,
+  } = options;
+
+  const [attempt, setAttempt] = useState(0);
+  const [isReconnecting, setIsReconnecting] = useState(false);
+  const reconnectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const wasConnectedRef = useRef(false);
+  const isConnectedRef = useRef(false);
+
+  useEffect(() => { isConnectedRef.current = connected; }, [connected]);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    if (connected) {
+      wasConnectedRef.current = true;
+      if (reconnectTimeoutRef.current) { clearTimeout(reconnectTimeoutRef.current); reconnectTimeoutRef.current = null; }
+      setAttempt(0);
+      setIsReconnecting(false);
+    } else if (wasConnectedRef.current && !connected && !isReconnecting && !reconnecting) {
+      if (attempt < maxAttempts) {
+        setIsReconnecting(true);
+        const delay = Math.pow(2, attempt) * 1000;
+        reconnectTimeoutRef.current = setTimeout(async () => {
+          if (isConnectedRef.current) { setIsReconnecting(false); return; }
+          onNotification?.(`Auto-reconnect attempt ${attempt + 1}/${maxAttempts}`, 'info');
+          try {
+            const result = await reconnect();
+            if (!result?.success) setAttempt(prev => prev + 1);
+          } catch {
+            onNotification?.('Auto-reconnect failed', 'error');
+            setAttempt(prev => prev + 1);
+          }
+          setIsReconnecting(false);
+        }, delay);
+      }
+    }
+    return () => { if (reconnectTimeoutRef.current) clearTimeout(reconnectTimeoutRef.current); };
+  }, [connected, attempt, isReconnecting, reconnecting, reconnect, enabled, maxAttempts, onNotification]);
+
+  const reset = useCallback(() => {
+    setAttempt(0);
+    setIsReconnecting(false);
+    if (reconnectTimeoutRef.current) { clearTimeout(reconnectTimeoutRef.current); reconnectTimeoutRef.current = null; }
+  }, []);
+
+  return { attempt, isReconnecting, reset };
+}

--- a/packages/react/src/hooks/useTerminal.ts
+++ b/packages/react/src/hooks/useTerminal.ts
@@ -71,7 +71,16 @@ export function useTerminalConnection(adapter: TerminalAdapter) {
 }
 
 /**
- * Hook for terminal screen content with polling.
+ * Hook for terminal screen content with polling + push subscription.
+ *
+ * If the adapter exposes `onScreen(listener)` (e.g. WebSocketAdapter), we
+ * subscribe to it so server-initiated updates surface to React state
+ * instantly. This is what keeps backspace/delete/edit operations visually
+ * in sync with the cursor — without the subscription, content would only
+ * refresh on the next poll tick (up to `interval` ms later), producing a
+ * visible lag where the cursor moved but the character stayed on screen.
+ *
+ * Polling still runs as a reliability fallback.
  */
 export function useTerminalScreen(
   adapter: TerminalAdapter,
@@ -101,8 +110,15 @@ export function useTerminalScreen(
     poll(); // Initial fetch
     intervalRef.current = setInterval(poll, interval);
 
+    // Subscribe to pushed updates if the adapter supports them.
+    const unsubscribe = adapter.onScreen?.((screen) => {
+      setData(screen);
+      setError(null);
+    });
+
     return () => {
       if (intervalRef.current) clearInterval(intervalRef.current);
+      unsubscribe?.();
     };
   }, [adapter, interval, enabled]);
 

--- a/packages/react/src/hooks/useTerminalState.ts
+++ b/packages/react/src/hooks/useTerminalState.ts
@@ -1,0 +1,176 @@
+import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
+import type { TerminalAdapter, ScreenData, ConnectionStatus, SendResult, Field } from '../adapters/types';
+import { useTerminalScreen, useTerminalInput, useTerminalConnection } from './useTerminal';
+import { useTypingAnimation } from './useTypingAnimation';
+
+/**
+ * True if the screen content is effectively empty — all spaces, NULs, or
+ * whitespace. Used to detect the "host blanked the screen but hasn't sent
+ * replacement content yet" transit state.
+ */
+function isBlankContent(content: string | undefined): boolean {
+  if (!content) return true;
+  for (let i = 0; i < content.length; i++) {
+    const ch = content.charCodeAt(i);
+    if (ch !== 0x20 && ch !== 0x09 && ch !== 0x0a && ch !== 0x0d && ch !== 0x00 && ch !== 0xa0) {
+      return false;
+    }
+  }
+  return true;
+}
+
+export interface UseTerminalStateOptions {
+  /** Adapter for communicating with the terminal backend */
+  adapter: TerminalAdapter;
+  /** Polling interval in ms (0 to disable; default 2000) */
+  pollInterval?: number;
+  /** Direct screen data injection (bypasses polling) */
+  externalScreenData?: ScreenData | null;
+  /** Direct connection status injection */
+  externalStatus?: ConnectionStatus | null;
+  /** Enable typing animation (default false) */
+  typingAnimation?: boolean;
+  /** Typing animation budget in ms (default 60) */
+  typingBudgetMs?: number;
+  /** Callback when screen content changes */
+  onScreenChange?: (screen: ScreenData) => void;
+}
+
+export interface UseTerminalStateResult {
+  /** Processed screen data (with typing animation applied) */
+  screenData: ScreenData | null;
+  /** Raw screen data before typing animation */
+  rawScreenData: ScreenData | null;
+  /** Connection status */
+  connectionStatus: ConnectionStatus;
+  /** Send text input */
+  sendText: (text: string) => Promise<SendResult>;
+  /** Send a special key */
+  sendKey: (key: string) => Promise<SendResult>;
+  /** Establish a connection */
+  connect: (config?: any) => Promise<{ success: boolean; error?: string }>;
+  /** Reconnect */
+  reconnect: () => Promise<{ success: boolean; error?: string }>;
+  /** Whether a reconnect is in progress */
+  reconnecting: boolean;
+  /** Connection error */
+  connectError: string | null;
+  /** Screen polling error */
+  screenError: unknown;
+  /** Whether the host is in a busy (blank+locked) state */
+  isBusy: boolean;
+  /** How long the busy state has lasted (ms) */
+  busyElapsedMs: number;
+  /** Whether the busy overlay should be shown (after delay) */
+  showBusyOverlay: boolean;
+  /** Animated cursor position (from typing animation) or null */
+  animatedCursorPos: { row: number; col: number } | null;
+}
+
+const BUSY_OVERLAY_DELAY_MS = 600;
+
+/**
+ * Core terminal state management hook.
+ *
+ * Bundles screen data polling, blank-screen stashing, busy overlay timing,
+ * typing animation, and connection management. Use this hook to build a
+ * fully custom terminal UI without the GreenScreenTerminal component.
+ */
+export function useTerminalState(options: UseTerminalStateOptions): UseTerminalStateResult {
+  const {
+    adapter,
+    pollInterval = 2000,
+    externalScreenData,
+    externalStatus,
+    typingAnimation = false,
+    typingBudgetMs = 60,
+    onScreenChange,
+  } = options;
+
+  // --- Data sources ---
+  const shouldPoll = pollInterval > 0 && !externalScreenData;
+  const { data: polledScreenData, error: screenError } = useTerminalScreen(adapter, pollInterval, shouldPoll);
+  const { sendText: _sendText, sendKey: _sendKey } = useTerminalInput(adapter);
+  const { connect, reconnect, loading: reconnecting, error: connectError } = useTerminalConnection(adapter);
+
+  const incomingScreenData = externalScreenData ?? polledScreenData;
+
+  // --- Sticky last-contentful screen ---
+  const lastContentfulRef = useRef<ScreenData | null>(null);
+  useEffect(() => {
+    if (incomingScreenData && !isBlankContent(incomingScreenData.content)) {
+      lastContentfulRef.current = incomingScreenData;
+    }
+  }, [incomingScreenData]);
+
+  const isBlankLocked = !!(
+    incomingScreenData &&
+    incomingScreenData.keyboard_locked &&
+    isBlankContent(incomingScreenData.content)
+  );
+
+  const rawScreenData = useMemo(() => {
+    if (isBlankLocked && lastContentfulRef.current) {
+      return { ...lastContentfulRef.current, keyboard_locked: true };
+    }
+    return incomingScreenData;
+  }, [incomingScreenData, isBlankLocked]);
+
+  // --- Busy overlay timer ---
+  const [lockElapsedMs, setLockElapsedMs] = useState(0);
+  useEffect(() => {
+    if (!isBlankLocked) {
+      setLockElapsedMs(0);
+      return;
+    }
+    const start = Date.now();
+    setLockElapsedMs(0);
+    const id = setInterval(() => setLockElapsedMs(Date.now() - start), 250);
+    return () => clearInterval(id);
+  }, [isBlankLocked]);
+  const showBusyOverlay = isBlankLocked && lockElapsedMs >= BUSY_OVERLAY_DELAY_MS;
+
+  // --- Connection status ---
+  const connectionStatus = externalStatus ?? (rawScreenData ? { connected: true, status: 'authenticated' as const } : { connected: false, status: 'disconnected' as const });
+
+  // --- Typing animation ---
+  const { displayedContent, animatedCursorPos } = useTypingAnimation(
+    rawScreenData?.content,
+    typingAnimation,
+    typingBudgetMs,
+  );
+
+  const screenData = useMemo(() => {
+    if (!rawScreenData) return null;
+    return { ...rawScreenData, content: displayedContent };
+  }, [rawScreenData, displayedContent]);
+
+  // --- Notify parent on screen changes ---
+  const prevScreenSigRef = useRef<string | undefined>(undefined);
+  useEffect(() => {
+    if (screenData && onScreenChange && screenData.screen_signature !== prevScreenSigRef.current) {
+      prevScreenSigRef.current = screenData.screen_signature;
+      onScreenChange(screenData);
+    }
+  }, [screenData, onScreenChange]);
+
+  const sendText = useCallback(async (text: string) => _sendText(text), [_sendText]);
+  const sendKey = useCallback(async (key: string) => _sendKey(key), [_sendKey]);
+
+  return {
+    screenData: screenData ?? null,
+    rawScreenData: rawScreenData ?? null,
+    connectionStatus,
+    sendText,
+    sendKey,
+    connect,
+    reconnect,
+    reconnecting,
+    connectError,
+    screenError,
+    isBusy: isBlankLocked,
+    busyElapsedMs: lockElapsedMs,
+    showBusyOverlay,
+    animatedCursorPos,
+  };
+}

--- a/packages/react/src/hooks/useTypingAnimation.ts
+++ b/packages/react/src/hooks/useTypingAnimation.ts
@@ -215,15 +215,14 @@ export function useTypingAnimation(
     if (content === currentTarget) return;
 
     if (isAnimatingRef.current) {
-      // Queue everything — including screen transitions — so the in-progress
-      // typing animation reaches its final state before the next content is
-      // shown. Previously we called showInstant() here, which cancelled the
-      // animation mid-flight and made the typed field look half-filled right
-      // before the screen advanced. processNextRef handles both field entries
-      // (re-animate) and screen transitions (showInstant) after finishAnimation.
-      contentQueueRef.current.push(content);
-      if (contentQueueRef.current.length > 3) {
-        contentQueueRef.current = contentQueueRef.current.slice(-2);
+      if (!isFieldEntry(currentTarget, content)) {
+        contentQueueRef.current = [];
+        showInstant(content);
+      } else {
+        contentQueueRef.current.push(content);
+        if (contentQueueRef.current.length > 3) {
+          contentQueueRef.current = contentQueueRef.current.slice(-2);
+        }
       }
       return;
     }

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,6 +1,6 @@
 // Components
 export { GreenScreenTerminal } from './components/GreenScreenTerminal';
-export type { GreenScreenTerminalProps } from './components/GreenScreenTerminal';
+export type { GreenScreenTerminalProps, TerminalHeaderState } from './components/GreenScreenTerminal';
 export { TerminalBootLoader } from './components/TerminalBootLoader';
 export type { TerminalBootLoaderProps } from './components/TerminalBootLoader';
 export { InlineSignIn } from './components/InlineSignIn';
@@ -34,6 +34,10 @@ export {
   useTerminalScreen,
   useTerminalInput,
 } from './hooks/useTerminal';
+export { useTerminalState } from './hooks/useTerminalState';
+export type { UseTerminalStateOptions, UseTerminalStateResult } from './hooks/useTerminalState';
+export { useAutoReconnect } from './hooks/useAutoReconnect';
+export type { UseAutoReconnectOptions, UseAutoReconnectResult } from './hooks/useAutoReconnect';
 
 // Protocols
 export { getProtocolProfile } from './protocols/registry';

--- a/packages/react/src/styles/terminal.css
+++ b/packages/react/src/styles/terminal.css
@@ -1,19 +1,24 @@
 /* green-screen-react — Multi-protocol Legacy Terminal Emulator Styles */
 
 :root {
-  --gs-green: #10b981;
-  --gs-white: #FFFFFF;
-  --gs-blue: #7B93FF;
-  --gs-cyan: #00FFFF;
-  --gs-turquoise: #00FFFF;
-  --gs-yellow: #FFFF00;
-  --gs-red: #FF5555;
-  --gs-pink: #FF55FF;
-  --gs-bg: #000000;
-  --gs-card-bg: #0e1422;
-  --gs-card-border: #1e293b;
-  --gs-header-bg: #090e1a;
-  --gs-muted: #94a3b8;
+  /* Catppuccin Mocha palette */
+  --gs-green: #a6e3a1;
+  --gs-white: #cdd6f4;
+  --gs-blue: #89b4fa;
+  --gs-cyan: #94e2d5;
+  --gs-turquoise: #94e2d5;
+  --gs-yellow: #f9e2af;
+  --gs-red: #f38ba8;
+  --gs-pink: #f5c2e7;
+  --gs-bg: #1e1e2e;
+  --gs-card-bg: #181825;
+  --gs-card-border: #313244;
+  --gs-header-bg: #11111b;
+  --gs-muted: #6c7086;
+  --gs-surface: #313244;
+  --gs-accent: #cba6f7;
+  --gs-radius: 10px;
+  --gs-radius-inner: 6px;
   /*
    * Monospace font stack with CJK fallbacks. Japanese and other CJK glyphs
    * need a separate font since JetBrains Mono / Courier New don't cover
@@ -27,21 +32,94 @@
     monospace;
 }
 
+/* ── Theme: Classic (ACS / Mocha 5250 style) ─────────────────────── */
+/* A high-contrast black-background palette matching the classic IBM i
+ * desktop clients. Selected via the `theme="classic"` prop on the
+ * <GreenScreenTerminal> component, which adds `gs-theme-classic` to the
+ * root .gs-terminal element. */
+.gs-theme-classic {
+  --gs-green: #29fa29;       /* bright phosphor green */
+  --gs-white: #ffffff;
+  --gs-blue: #6aaaff;        /* title/F-key blue */
+  --gs-cyan: #00ffff;
+  --gs-turquoise: #2fd0e8;
+  --gs-yellow: #ffff40;
+  --gs-red: #ff2a2a;
+  --gs-pink: #ff6ec7;
+  --gs-bg: #000000;
+  --gs-card-bg: #000000;
+  --gs-card-border: #1a1a1a;
+  --gs-header-bg: #0a0a0a;
+  --gs-muted: #8a8a8a;
+  --gs-surface: #1a1a1a;
+  --gs-accent: #29fa29;       /* cursor/active accent in classic = green */
+  --gs-radius: 0px;
+  --gs-radius-inner: 0px;
+}
+
+/* Classic theme: enforce sharp corners on elements that use hardcoded
+ * border-radius values instead of the --gs-radius tokens (e.g. badges,
+ * shortcut keys, inline button chrome). Keeps the authentic blocky
+ * terminal aesthetic. */
+.gs-theme-classic .gs-badge-lock,
+.gs-theme-classic .gs-badge-ins,
+.gs-theme-classic .gs-badge-focused,
+.gs-theme-classic .gs-shortcut-action,
+.gs-theme-classic .gs-shortcut-fkey,
+.gs-theme-classic .gs-btn-icon,
+.gs-theme-classic .gs-disconnect-btn,
+.gs-theme-classic .gs-signin-btn,
+.gs-theme-classic .gs-window,
+.gs-theme-classic .gs-error-banner,
+.gs-theme-classic .gs-shortcuts-panel,
+.gs-theme-classic input,
+.gs-theme-classic select,
+.gs-theme-classic button {
+  border-radius: 0 !important;
+}
+
 /* ── Terminal Container ───────────────────────────────────────────── */
 
 .gs-terminal {
   background-color: var(--gs-card-bg);
   border: 1px solid var(--gs-card-border);
+  border-radius: var(--gs-radius);
   display: flex;
   flex-direction: column;
   height: 100%;
   overflow: hidden;
-  transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4), 0 2px 8px rgba(0, 0, 0, 0.2);
 }
 
+/* Focused-border glow uses the theme accent color so the Classic theme
+ * gets a green halo and Modern gets the purple halo. color-mix() keeps
+ * the semi-transparent tints without hardcoding RGB values per theme. */
 .gs-terminal-focused {
-  border-color: rgba(16, 185, 129, 0.4);
-  box-shadow: 0 0 6px rgba(16, 185, 129, 0.1);
+  border-color: color-mix(in srgb, var(--gs-accent) 40%, transparent);
+  box-shadow:
+    0 8px 32px rgba(0, 0, 0, 0.5),
+    0 0 0 1px color-mix(in srgb, var(--gs-accent) 15%, transparent);
+}
+
+/* Suppress the browser's default dotted/dashed focus outline on non-input
+ * elements inside the terminal. F-keys (esp. F12) can cause focus to jump
+ * to the container or a div, leaving a persistent dashed outline that
+ * doesn't clear on subsequent screen updates. Intentional focus (the
+ * hidden input, shortcut panel buttons, disconnect button) are styled
+ * separately and don't need the default outline. */
+.gs-terminal:focus,
+.gs-terminal *:focus,
+.gs-screen:focus,
+.gs-screen-content:focus,
+.gs-screen-content *:focus {
+  outline: none;
+}
+.gs-terminal .gs-btn-icon:focus-visible,
+.gs-terminal .gs-disconnect-btn:focus-visible,
+.gs-terminal .gs-signin-btn:focus-visible {
+  outline: 2px solid var(--gs-accent);
+  outline-offset: 2px;
 }
 
 /* ── Header ───────────────────────────────────────────────────────── */
@@ -49,21 +127,20 @@
 .gs-header {
   background-color: var(--gs-header-bg);
   border-bottom: 1px solid var(--gs-card-border);
-  padding: 0.5rem 1rem;
-  font-family: var(--gs-font);
-  font-size: 0.75rem;
-  font-weight: 400;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
+  padding: 0 16px;
+  height: 38px;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+  font-size: 13px;
+  font-weight: 500;
   color: var(--gs-muted);
   display: flex;
   align-items: center;
   justify-content: space-between;
+  position: relative;
 }
 
 .gs-terminal-focused .gs-header {
-  background-color: rgba(16, 185, 129, 0.04);
-  border-bottom-color: rgba(16, 185, 129, 0.3);
+  border-bottom-color: rgba(203, 166, 247, 0.2);
 }
 
 .gs-header-left {
@@ -86,69 +163,77 @@
 
 .gs-badge-focused {
   padding: 2px 8px;
-  background-color: rgba(16, 185, 129, 0.15);
-  color: var(--gs-green);
+  background-color: rgba(203, 166, 247, 0.12);
+  color: var(--gs-accent);
   font-size: 10px;
   font-weight: 600;
-  border-radius: 4px;
-  border: 1px solid rgba(16, 185, 129, 0.3);
+  border-radius: var(--gs-radius-inner);
+  border: 1px solid rgba(203, 166, 247, 0.25);
 }
 
 .gs-badge-lock {
-  padding: 2px 6px;
-  background-color: #EF4444;
-  color: white;
+  padding: 2px 8px;
+  background-color: rgba(243, 139, 168, 0.15);
+  color: var(--gs-red);
   font-size: 10px;
-  font-weight: bold;
-  border-radius: 4px;
+  font-weight: 600;
+  border-radius: var(--gs-radius-inner);
+  border: 1px solid rgba(243, 139, 168, 0.3);
 }
 
 .gs-badge-ins {
-  padding: 2px 6px;
-  background-color: #F59E0B;
-  color: black;
+  padding: 2px 8px;
+  background-color: rgba(249, 226, 175, 0.12);
+  color: var(--gs-yellow);
   font-size: 10px;
-  font-weight: bold;
-  border-radius: 4px;
+  font-weight: 600;
+  border-radius: var(--gs-radius-inner);
+  border: 1px solid rgba(249, 226, 175, 0.25);
 }
 
 .gs-timestamp {
   font-family: var(--gs-font);
   font-size: 10px;
-  color: #808080;
+  color: var(--gs-muted);
 }
 
 .gs-hint {
   font-family: var(--gs-font);
   font-size: 10px;
-  color: #7a8594;
+  color: var(--gs-muted);
 }
 
 .gs-host {
   font-family: var(--gs-font);
   font-size: 12px;
-  color: #808080;
+  color: var(--gs-muted);
 }
 
 .gs-disconnected-text {
   font-family: var(--gs-font);
   font-size: 12px;
-  color: #FF6B00;
+  color: var(--gs-red);
 }
 
 .gs-btn-icon {
   background: transparent;
   border: none;
-  padding: 4px;
-  border-radius: 4px;
+  /* Padding upped so the icon's click area matches the rendered height
+   * of the adjacent 'TN5250' header title; keeps the icon + title line
+   * visually balanced in the 38px header. */
+  padding: 6px 8px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--gs-radius-inner);
   color: var(--gs-muted);
   cursor: pointer;
-  transition: background-color 0.15s, color 0.15s;
+  transition: background-color 0.12s, color 0.12s;
 }
 
 .gs-btn-icon:hover {
-  background-color: #1A1A1A;
-  color: var(--gs-green);
+  background-color: var(--gs-surface);
+  color: var(--gs-white);
 }
 
 .gs-btn-icon:disabled {
@@ -173,6 +258,11 @@
   flex-direction: column;
   flex-shrink: 0;
   cursor: text;
+  /* Prevent content (e.g. wide STRSQL / 132-col screens, wrapped fields
+   * whose rendered span exceeds the declared column count) from escaping
+   * the terminal's rounded container on the right side. */
+  overflow: hidden;
+  max-width: 100%;
 }
 
 .gs-screen-embedded {
@@ -180,7 +270,7 @@
 }
 
 .gs-screen-content {
-  padding: 8px 12px;
+  padding: 12px 16px;
   flex-shrink: 0;
 }
 
@@ -188,14 +278,15 @@
 
 .gs-cursor {
   display: block;
-  background-color: var(--gs-green);
-  animation: gs-cursor-blink 1s infinite;
-  box-shadow: 0 0 5px rgba(16, 185, 129, 0.5);
+  background-color: var(--gs-accent);
+  animation: gs-cursor-blink 1.2s ease-in-out infinite;
+  border-radius: 1px;
 }
 
 @keyframes gs-cursor-blink {
-  0%, 50% { opacity: 0.8; }
-  51%, 100% { opacity: 0; }
+  0%, 45% { opacity: 0.9; }
+  50%, 95% { opacity: 0; }
+  100% { opacity: 0.9; }
 }
 
 /* ── Row Colors (protocol-driven via CSS classes) ─────────────────── */
@@ -221,14 +312,14 @@
 .gs-input-field {
   display: inline-block;
   position: relative;
-  border-bottom: 1px solid rgba(16, 185, 129, 0.45);
+  border-bottom: 1px solid rgba(166, 227, 161, 0.3);
 }
 
 /* Active input field — accent border when cursor is inside (highlight-on-entry).
  * Combined with the per-span inline style when the host declares a
  * highlight_entry_attr FCW. */
 .gs-field-active {
-  box-shadow: inset 0 -2px 0 0 var(--gs-yellow, #FFFF00);
+  border-bottom-color: var(--gs-accent);
 }
 
 /* DBCS input field marker — faint background tint to signal CJK input mode.
@@ -248,14 +339,16 @@
 .gs-overlay {
   position: absolute;
   inset: 0;
-  background-color: rgba(0, 0, 0, 0.7);
+  background-color: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   z-index: 10;
   pointer-events: none;
-  color: #FF6B00;
+  color: var(--gs-muted);
   font-family: var(--gs-font);
   font-size: 14px;
   gap: 12px;
@@ -268,14 +361,16 @@
 .gs-busy-overlay {
   position: absolute;
   inset: 0;
-  background-color: rgba(0, 0, 0, 0.35);
+  background-color: rgba(30, 30, 46, 0.4);
+  backdrop-filter: blur(2px);
+  -webkit-backdrop-filter: blur(2px);
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   z-index: 9;
   pointer-events: none;
-  color: var(--gs-yellow, #FFFF00);
+  color: var(--gs-yellow);
   font-family: var(--gs-font);
   gap: 8px;
   animation: gs-fade-in 180ms ease-out;
@@ -303,35 +398,38 @@
   transform: translateX(-50%);
   z-index: 10;
   padding: 12px;
-  background-color: #1A0000;
-  border: 1px solid #FF6B00;
-  border-radius: 4px;
+  background-color: rgba(243, 139, 168, 0.1);
+  border: 1px solid rgba(243, 139, 168, 0.3);
+  border-radius: var(--gs-radius-inner);
   display: flex;
   align-items: center;
   gap: 8px;
   font-family: var(--gs-font);
   font-size: 12px;
-  color: #FF6B00;
+  color: var(--gs-red);
 }
 
 /* ── Shortcuts Panel ──────────────────────────────────────────────── */
 
 .gs-shortcuts-panel {
   position: absolute;
-  bottom: 8px;
-  right: 8px;
+  bottom: 12px;
+  right: 12px;
   z-index: 8;
-  background-color: rgba(14, 20, 34, 0.95);
+  background-color: rgba(24, 24, 37, 0.85);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
   border: 1px solid var(--gs-card-border);
-  border-radius: 4px;
-  padding: 8px 10px;
+  border-radius: var(--gs-radius);
+  padding: 12px 14px;
   font-family: var(--gs-font);
   font-size: 11px;
   color: var(--gs-muted);
   pointer-events: auto;
-  animation: gs-fade-in 200ms ease-out;
+  animation: gs-fade-in 150ms ease-out;
   max-height: 90%;
   overflow-y: auto;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
 }
 
 .gs-shortcuts-header {
@@ -339,9 +437,8 @@
   justify-content: space-between;
   align-items: center;
   margin-bottom: 6px;
-  color: var(--gs-green);
+  color: var(--gs-accent);
   font-size: 11px;
-  letter-spacing: 0.05em;
 }
 
 .gs-shortcuts-section-title {
@@ -372,11 +469,11 @@
 }
 
 .gs-shortcut-action:hover {
-  background-color: rgba(16, 185, 129, 0.12);
+  background-color: rgba(203, 166, 247, 0.1);
 }
 
 .gs-shortcut-key {
-  color: var(--gs-green);
+  color: var(--gs-accent);
   font-weight: 500;
   white-space: nowrap;
 }
@@ -406,20 +503,20 @@
 }
 
 .gs-shortcut-fkey {
-  background: transparent;
+  background: rgba(49, 50, 68, 0.5);
   border: 1px solid var(--gs-card-border);
-  border-radius: 3px;
-  padding: 3px 0;
-  color: var(--gs-green);
+  border-radius: var(--gs-radius-inner);
+  padding: 4px 0;
+  color: var(--gs-accent);
   font-family: var(--gs-font);
   font-size: 10px;
   cursor: pointer;
-  transition: background-color 0.1s, border-color 0.1s;
+  transition: background-color 0.12s, border-color 0.12s;
 }
 
 .gs-shortcut-fkey:hover {
-  background-color: rgba(16, 185, 129, 0.15);
-  border-color: var(--gs-green);
+  background-color: rgba(203, 166, 247, 0.12);
+  border-color: rgba(203, 166, 247, 0.4);
 }
 
 /* ── Inline Sign-In ──────────────────────────────────────────────── */
@@ -440,37 +537,167 @@
 
 .gs-signin input:focus,
 .gs-signin select:focus {
-  border-color: var(--gs-green);
-  box-shadow: 0 0 4px rgba(16, 185, 129, 0.3);
+  border-color: var(--gs-accent);
+  box-shadow: 0 0 4px rgba(203, 166, 247, 0.3);
 }
 
 .gs-signin select option {
-  background-color: #0e1422;
-  color: var(--gs-green);
+  background-color: var(--gs-card-bg);
+  color: var(--gs-white);
 }
 
 .gs-signin-btn {
   width: 100%;
-  padding: 8px;
+  padding: 10px;
   margin-top: 4px;
-  background-color: rgba(16, 185, 129, 0.15);
-  border: 1px solid var(--gs-green);
-  color: var(--gs-green);
-  font-family: var(--gs-font);
-  font-size: 12px;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
+  background-color: rgba(203, 166, 247, 0.12);
+  border: 1px solid rgba(203, 166, 247, 0.3);
+  border-radius: var(--gs-radius-inner);
+  color: var(--gs-accent);
+  font-family: -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+  font-size: 13px;
+  font-weight: 500;
   cursor: pointer;
   transition: background-color 0.15s;
 }
 
+/* Disclosure toggle: "Show all params" / "Hide all params" with a
+ * chevron that rotates 180° when expanded. Collapses Screen Size,
+ * Username, Password by default to keep the initial form minimal. */
+.gs-signin-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  background: transparent;
+  border: none;
+  padding: 4px 0;
+  align-self: flex-start;
+  color: var(--gs-muted);
+  font-family: inherit;
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+  transition: color 0.15s;
+}
+
+.gs-signin-toggle:hover,
+.gs-signin-toggle:focus-visible {
+  color: var(--gs-accent);
+  outline: none;
+}
+
 .gs-signin-btn:hover:not(:disabled) {
-  background-color: rgba(16, 185, 129, 0.25);
+  background-color: rgba(203, 166, 247, 0.2);
 }
 
 .gs-signin-btn:disabled {
   opacity: 0.4;
   cursor: not-allowed;
+}
+
+/* ── Disconnect Button ───────────────────────────────────────────── */
+
+.gs-disconnect-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 5px 8px;
+  border-radius: var(--gs-radius-inner);
+  background: transparent;
+  border: 1px solid rgba(205, 214, 244, 0.12);
+  color: rgba(205, 214, 244, 0.45);
+  font-family: -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+  font-size: 11px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s, background-color 0.15s;
+}
+
+.gs-disconnect-btn:hover {
+  color: var(--gs-red);
+  border-color: rgba(243, 139, 168, 0.35);
+  background-color: rgba(243, 139, 168, 0.08);
+}
+
+.gs-disconnect-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* ── Header Title (centered) ─────────────────────────────────────── */
+
+.gs-header-title {
+  /* Left-anchored: title sits on the left side of the header, just after
+   * the keyboard button and badges. `margin-right: auto` pushes the
+   * right-group elements (status, disconnect) to the opposite edge. */
+  margin-right: auto;
+  margin-left: 0.5rem;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--gs-muted);
+  pointer-events: none;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 50%;
+}
+
+/* ── WDSF Popup Window Overlay ───────────────────────────────────── */
+
+/* Styled frame drawn over the proxy's ASCII window border cells (which
+ * are blanked in renderRowWithFields when the metadata is present). Real
+ * 5250 clients (Mocha, ACS) render popups this way — a rounded accent
+ * border with a soft shadow — rather than the literal `:` and `.`
+ * characters the host sends for DBCS/terminal fallback. */
+.gs-window {
+  box-sizing: border-box;
+  border: 1px solid var(--gs-accent);
+  border-radius: var(--gs-radius-inner);
+  background: rgba(17, 17, 27, 0.35);
+  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.5), 0 0 0 1px rgba(203, 166, 247, 0.12);
+}
+
+/* Window title: centered badge on the top edge of the frame.
+ * Uses a tiny negative top offset so it sits on the border line. */
+.gs-window-title,
+.gs-window-footer {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 0 8px;
+  font-family: var(--gs-font);
+  font-size: 11px;
+  line-height: 1;
+  color: var(--gs-accent);
+  background: var(--gs-bg);
+  letter-spacing: 0.03em;
+  white-space: nowrap;
+}
+
+.gs-window-title {
+  top: -6px;
+}
+
+.gs-window-footer {
+  bottom: -6px;
+  color: var(--gs-muted);
+}
+
+/* ── Connection Icon ─────────────────────────────────────────────── */
+
+.gs-connection-icon {
+  flex-shrink: 0;
+  display: inline-block;
+}
+
+.gs-connection-icon-connected {
+  color: var(--gs-green);
+}
+
+.gs-connection-icon-disconnected {
+  color: var(--gs-red);
 }
 
 /* ── Animations ───────────────────────────────────────────────────── */

--- a/packages/react/src/styles/tn5250.css
+++ b/packages/react/src/styles/tn5250.css
@@ -1,18 +1,19 @@
 /* green-screen-react — Legacy Terminal Emulator Styles */
 
 :root {
-  --gs-green: #10b981;
-  --gs-white: #FFFFFF;
-  --gs-blue: #7B93FF;
-  --gs-cyan: #00FFFF;
-  --gs-yellow: #FFFF00;
-  --gs-red: #FF5555;
-  --gs-pink: #FF55FF;
-  --gs-bg: #000000;
-  --gs-card-bg: #0e1422;
-  --gs-card-border: #1e293b;
-  --gs-header-bg: #090e1a;
-  --gs-muted: #94a3b8;
+  /* Catppuccin Mocha palette */
+  --gs-green: #a6e3a1;
+  --gs-white: #cdd6f4;
+  --gs-blue: #89b4fa;
+  --gs-cyan: #94e2d5;
+  --gs-yellow: #f9e2af;
+  --gs-red: #f38ba8;
+  --gs-pink: #f5c2e7;
+  --gs-bg: #1e1e2e;
+  --gs-card-bg: #181825;
+  --gs-card-border: #313244;
+  --gs-header-bg: #11111b;
+  --gs-muted: #6c7086;
   --gs-font: 'JetBrains Mono', 'Courier New', monospace;
 
   /* Legacy aliases */
@@ -36,16 +37,18 @@
 .gs-terminal {
   background-color: var(--gs-card-bg);
   border: 1px solid var(--gs-card-border);
+  border-radius: var(--gs-radius, 10px);
   display: flex;
   flex-direction: column;
   height: 100%;
   overflow: hidden;
-  transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4), 0 2px 8px rgba(0, 0, 0, 0.2);
 }
 
 .gs-terminal-focused {
-  border-color: rgba(16, 185, 129, 0.4);
-  box-shadow: 0 0 6px rgba(16, 185, 129, 0.1);
+  border-color: rgba(203, 166, 247, 0.4);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5), 0 0 0 1px rgba(203, 166, 247, 0.15);
 }
 
 /* ── Header ───────────────────────────────────────────────────────── */
@@ -53,21 +56,20 @@
 .gs-header {
   background-color: var(--gs-header-bg);
   border-bottom: 1px solid var(--gs-card-border);
-  padding: 0.5rem 1rem;
-  font-family: var(--gs-font);
-  font-size: 0.75rem;
-  font-weight: 400;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
+  padding: 0 16px;
+  height: 38px;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+  font-size: 13px;
+  font-weight: 500;
   color: var(--gs-muted);
   display: flex;
   align-items: center;
   justify-content: space-between;
+  position: relative;
 }
 
 .gs-terminal-focused .gs-header {
-  background-color: rgba(16, 185, 129, 0.04);
-  border-bottom-color: rgba(16, 185, 129, 0.3);
+  border-bottom-color: rgba(203, 166, 247, 0.2);
 }
 
 .gs-header-left {
@@ -90,30 +92,32 @@
 
 .gs-badge-focused {
   padding: 2px 8px;
-  background-color: rgba(16, 185, 129, 0.15);
-  color: var(--gs-green);
+  background-color: rgba(203, 166, 247, 0.12);
+  color: var(--gs-accent, #cba6f7);
   font-size: 10px;
   font-weight: 600;
-  border-radius: 4px;
-  border: 1px solid rgba(16, 185, 129, 0.3);
+  border-radius: 6px;
+  border: 1px solid rgba(203, 166, 247, 0.25);
 }
 
 .gs-badge-lock {
-  padding: 2px 6px;
-  background-color: #EF4444;
-  color: white;
+  padding: 2px 8px;
+  background-color: rgba(243, 139, 168, 0.15);
+  color: var(--gs-red);
   font-size: 10px;
-  font-weight: bold;
-  border-radius: 4px;
+  font-weight: 600;
+  border-radius: 6px;
+  border: 1px solid rgba(243, 139, 168, 0.3);
 }
 
 .gs-badge-ins {
-  padding: 2px 6px;
-  background-color: #F59E0B;
-  color: black;
+  padding: 2px 8px;
+  background-color: rgba(249, 226, 175, 0.12);
+  color: var(--gs-yellow);
   font-size: 10px;
-  font-weight: bold;
-  border-radius: 4px;
+  font-weight: 600;
+  border-radius: 6px;
+  border: 1px solid rgba(249, 226, 175, 0.25);
 }
 
 .gs-timestamp {
@@ -137,22 +141,22 @@
 .gs-disconnected-text {
   font-family: var(--gs-font);
   font-size: 12px;
-  color: #FF6B00;
+  color: var(--gs-red);
 }
 
 .gs-btn-icon {
   background: transparent;
   border: none;
-  padding: 4px;
-  border-radius: 4px;
+  padding: 4px 6px;
+  border-radius: 6px;
   color: var(--gs-muted);
   cursor: pointer;
-  transition: background-color 0.15s, color 0.15s;
+  transition: background-color 0.12s, color 0.12s;
 }
 
 .gs-btn-icon:hover {
-  background-color: #1A1A1A;
-  color: var(--gs-green);
+  background-color: var(--gs-card-border);
+  color: var(--gs-white);
 }
 
 .gs-btn-icon:disabled {
@@ -191,14 +195,15 @@
 
 .gs-cursor {
   display: block;
-  background-color: var(--gs-green);
-  animation: gs-cursor-blink 1s infinite;
-  box-shadow: 0 0 5px rgba(16, 185, 129, 0.5);
+  background-color: var(--gs-accent, #cba6f7);
+  animation: gs-cursor-blink 1.2s ease-in-out infinite;
+  border-radius: 1px;
 }
 
 @keyframes gs-cursor-blink {
-  0%, 50% { opacity: 0.8; }
-  51%, 100% { opacity: 0; }
+  0%, 45% { opacity: 0.9; }
+  50%, 95% { opacity: 0; }
+  100% { opacity: 0.9; }
 }
 
 /* ── Row Colors (protocol-driven conventions) ─────────────────────── */
@@ -224,7 +229,7 @@
 .gs-input-field {
   display: inline-block;
   position: relative;
-  border-bottom: 2px solid var(--gs-green);
+  border-bottom: 1px solid rgba(166, 227, 161, 0.3);
 }
 
 /* ── Overlays ─────────────────────────────────────────────────────── */
@@ -232,14 +237,16 @@
 .gs-overlay {
   position: absolute;
   inset: 0;
-  background-color: rgba(0, 0, 0, 0.7);
+  background-color: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   z-index: 10;
   pointer-events: none;
-  color: #FF6B00;
+  color: var(--gs-muted);
   font-family: var(--gs-font);
   font-size: 14px;
   gap: 12px;
@@ -252,15 +259,15 @@
   transform: translateX(-50%);
   z-index: 10;
   padding: 12px;
-  background-color: #1A0000;
-  border: 1px solid #FF6B00;
-  border-radius: 4px;
+  background-color: rgba(243, 139, 168, 0.1);
+  border: 1px solid rgba(243, 139, 168, 0.3);
+  border-radius: 6px;
   display: flex;
   align-items: center;
   gap: 8px;
   font-family: var(--gs-font);
   font-size: 12px;
-  color: #FF6B00;
+  color: var(--gs-red);
 }
 
 /* ── Animations ───────────────────────────────────────────────────── */

--- a/packages/standalone/package.json
+++ b/packages/standalone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "green-screen-terminal",
-  "version": "1.2.6",
+  "version": "1.3.0",
   "description": "Standalone web-based terminal for TN5250, TN3270, VT220, and HP 6530 hosts — run with npx green-screen-terminal",
   "type": "module",
   "bin": {
@@ -14,7 +14,7 @@
     "build:ui": "cd ../../apps/demo && VITE_BASE_URL=/ npx vite build --outDir ../../packages/standalone/ui"
   },
   "dependencies": {
-    "green-screen-proxy": "^1.2.3",
+    "green-screen-proxy": "^1.3.0",
     "express": "^4.21.0"
   },
   "keywords": [

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "green-screen-types",
-  "version": "1.2.6",
+  "version": "1.3.0",
   "description": "Shared type definitions for green-screen-react and green-screen-proxy",
   "type": "module",
   "main": "src/index.ts",


### PR DESCRIPTION
## Summary

Release **v1.3.0** across all publishable packages (`green-screen-react`, `green-screen-proxy`, `green-screen-terminal`, `green-screen-types`).

### React package
- `GreenScreenTerminal`: new pluggability props — `theme` (`modern` | `classic`), `alwaysFocused`, `autoConnect`, `persistFocus`, configurable header. Extracted `useTerminalState` and `useAutoReconnect` hooks.
- WDSF/CREATE_WINDOW popups render as styled overlays; heuristic detector catches plain-char popups (dot-run + colon edges) that don't use WDSF.
- `InlineSignIn`: collapsible "Show all params" disclosure hides screen-size/username/password behind a toggle; non-secret fields persist in localStorage.
- Cursor positioning: subtract `.gs-screen-content` padding on click; optimistic cursor prediction for arrow keys + TAB.
- Multi-row field slicing via `fieldSliceForRow` (fixes underline rendering on wrapped fields).
- Keyboard-lock badge: optimistic state on submit-key presses; key icon stays gray when connected but not yet authenticated.
- Screen transitions queued during typing animation so mid-animation pushes don't clobber text.

### Proxy package
- `parser`: native-underscore attribute exception (types `0x04`-`0x06`) so synthetic fields aren't demoted to non-input — fixes missing input fields on STRSQL / Exit SQL screens.
- Sign-on detection switched to text matching (not field attributes); `attemptSignOff` detects the sign-on screen structurally.
- Keep-alive upgraded from TELNET NOP → Timing Mark (more reliable across IBM i hosts).
- Graceful SIGNOFF on proxy shutdown + `/disconnect-all` endpoint.
- Local-key REST path broadcasts screen update.

### Demo app
- Modern/Classic theme toggle with smooth side-switching (flex-grow pseudo-element animation).
- Per-theme stickers: brushed-metal gunmetal nameplate (Modern, left) / paper sticky-note with tape (Classic, right).
- LegacyBridge attribution: inline SVG chip + two-tone wordmark.
- Header redesign: `@green-screen-react` + **DEMO / PREVIEW** pill; title + npx pill + GitHub button laid out so title ↔ GitHub and subtitle ↔ npx align vertically.
- "Connect to your system" heading sits inside terminal's top-left.
- npx pill and GitHub button share 34px height and are always pinned to the terminal's right edge.

## Test plan
- [x] Modern theme: toggle pill on right, metal sticker on left, title phosphor-free
- [x] Classic theme: toggle pill on left, paper sticker on right, phosphor palette
- [x] IBM i Main Menu: command line underline visible, TAB navigates input fields
- [x] STRSQL / Exit SQL: input fields detected and navigable
- [x] Session restore across page reloads; beacon tears down on unload
- [ ] Cloudflare worker redeployed (bundles new proxy source) — see follow-up post-merge