### PR TITLE
fix(a11y): give the keyboard-capture input an accessible name

### DIFF
--- a/packages/react/src/components/GreenScreenTerminal.tsx
+++ b/packages/react/src/components/GreenScreenTerminal.tsx
@@ -1528,6 +1528,10 @@ export function GreenScreenTerminal({
             value={inputText}
             onChange={handleInput}
             onKeyDown={handleKeyDown}
+            // Visually-hidden keyboard-capture field (opacity:0). It is a focus
+            // target, so it needs an accessible name rather than aria-hidden —
+            // otherwise screen readers announce an unlabelled textbox (WCAG 4.1.2).
+            aria-label="Terminal input"
             style={{ position: 'absolute', opacity: 0, pointerEvents: 'none', fontSize: '13px', lineHeight: '21px', fontFamily: 'var(--gs-font)', padding: 0, border: 'none', height: '21px' }}
             autoComplete="off"
             autoCorrect="off"


### PR DESCRIPTION
## What
Add `aria-label="Terminal input"` to the visually-hidden (opacity:0) keyboard-capture `<input>` in `GreenScreenTerminal`.

## Why
The input is a focus target (it captures keystrokes for the terminal), so `aria-hidden` is wrong — it needs an accessible name. Without one, screen readers announce an unlabelled textbox, failing **WCAG 4.1.2 (Name, Role, Value)**. Surfaced by an axe-core sweep of the LegacyBridge operator console (1 critical violation: `label`).

## Scope
Protocol-generic, one attribute, no behaviour change. Releasing this (npm/PyPI) lets the LegacyBridge frontend pick it up via the usual submodule SHA bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)