### PR TITLE
fix(client-py): retain command_keys_no_transmit on ScreenBuffer

### DIFF
--- a/packages/client-py/green_screen_client/buffer.py
+++ b/packages/client-py/green_screen_client/buffer.py
@@ -49,6 +49,7 @@ class ScreenBuffer:
         self.ext_attrs: dict = {}
         self.dbcs_cont: List[int] = []
         self.code_page: str = "cp37"
+        self.command_keys_no_transmit: Optional[List[str]] = None
 
     def apply(self, screen: Optional[ScreenData]) -> None:
         if screen is None:
@@ -80,6 +81,11 @@ class ScreenBuffer:
         self.ext_attrs = {k: vars(v) for k, v in (screen.ext_attrs or {}).items()}
         self.dbcs_cont = list(screen.dbcs_cont or [])
         self.code_page = screen.code_page or "cp37"
+        self.command_keys_no_transmit = (
+            list(screen.command_keys_no_transmit)
+            if screen.command_keys_no_transmit
+            else None
+        )
 
     @staticmethod
     def _field_to_dict(field) -> dict:  # type: ignore[no-untyped-def]
@@ -99,9 +105,6 @@ class ScreenBuffer:
             "is_reverse": bool(field.is_reverse),
             "is_underscored": bool(field.is_underscored),
             "is_non_display": bool(field.is_non_display),
-            # PATCH-LOADED-CHECK: this line proves the patched buffer.py
-            # is being executed by the worker. Remove with the
-            # [MANDATORY-DEBUG] log after verification.
             "is_mandatory": bool(getattr(field, "mandatory_entry", None) or False),
             "color": field.color,
             "shift_type": field.shift_type,

--- a/packages/client-py/tests/test_buffer.py
+++ b/packages/client-py/tests/test_buffer.py
@@ -1,0 +1,43 @@
+"""ScreenBuffer.apply() must mirror every ScreenData attribute integrators
+read off the cached buffer. Regression guard for the CA/CF key-mask field,
+which was silently dropped here (the buffer is the shape REST integrations
+actually consume, so a field missing from apply() is invisible to them even
+when the proxy emits it).
+"""
+
+from green_screen_client.buffer import ScreenBuffer
+from green_screen_client.types import ScreenData
+
+
+def _screen(**overrides) -> ScreenData:
+    base = {
+        "content": "HELLO",
+        "cursor_row": 1,
+        "cursor_col": 2,
+        "rows": 24,
+        "cols": 80,
+        "fields": [],
+        "screen_signature": "sig",
+        "timestamp": "2026-01-01T00:00:00Z",
+    }
+    base.update(overrides)
+    return ScreenData.from_wire(base)
+
+
+def test_apply_retains_command_keys_no_transmit():
+    buf = ScreenBuffer()
+    assert buf.command_keys_no_transmit is None
+
+    buf.apply(_screen(command_keys_no_transmit=["F3", "F10", "F12"]))
+    assert buf.command_keys_no_transmit == ["F3", "F10", "F12"]
+
+
+def test_apply_clears_stale_mask_when_next_screen_has_none():
+    buf = ScreenBuffer()
+    buf.apply(_screen(command_keys_no_transmit=["F6"]))
+    assert buf.command_keys_no_transmit == ["F6"]
+
+    # Next screen carries no SOH key mask — a stale CA list must not
+    # survive, or the integrator would warn about the wrong screen.
+    buf.apply(_screen())
+    assert buf.command_keys_no_transmit is None


### PR DESCRIPTION
## Summary
- `ScreenBuffer.apply()` mirrored every `ScreenData` attribute **except** `command_keys_no_transmit` (the CA/CF key mask decoded from the 5250 SOH header), so REST integrations reading the cached buffer never saw which function keys the host marked Command-Attention — silently disabling any typed-input-loss warning built on it.
- Found by real-host validation against an IBM i LPAR: the proxy decoded the SOH mask bit-for-bit correctly (validated two-sided against an all-CA display file and a CA/CF-mixed one); the value was dropped at this buffer layer.
- The buffer now retains the mask and clears it when a subsequent screen carries none (a stale CA list must not describe the wrong screen).
- Also removes a stale `PATCH-LOADED-CHECK` debug comment whose companion log was already deleted.

## Test plan
- `python -m pytest packages/client-py/tests/` — new `test_buffer.py` covers retain + stale-clear; all 12 package tests pass.
- Live-validated end to end against a real TN5250 host (mask reaches the integrator payload).

🤖 Generated with [Claude Code](https://claude.com/claude-code)