### PR TITLE
TN3270 to production grade + VT interactive hardening + HP6530 conformance freeze

### DIFF
--- a/packages/client-py/green_screen_client/types.py
+++ b/packages/client-py/green_screen_client/types.py
@@ -47,6 +47,9 @@ class Field:
     is_underscored: Optional[bool] = None
     is_non_display: Optional[bool] = None
     color: Optional[FieldColor] = None
+    # Numeric-only input field (3270 field-attribute NUMERIC bit; 5250
+    # exposes the richer shift_type instead).
+    is_numeric: Optional[bool] = None
     highlight_entry_attr: Optional[int] = None
     resequence: Optional[int] = None
     progression_id: Optional[int] = None
@@ -81,6 +84,7 @@ class Field:
             is_underscored=data.get("is_underscored"),
             is_non_display=data.get("is_non_display"),
             color=data.get("color"),
+            is_numeric=data.get("is_numeric"),
             highlight_entry_attr=data.get("highlight_entry_attr"),
             resequence=data.get("resequence"),
             progression_id=data.get("progression_id"),

--- a/packages/proxy/src/hp6530/README.md
+++ b/packages/proxy/src/hp6530/README.md
@@ -1,0 +1,32 @@
+# HP 6530 engine — supported subset
+
+Best-effort support for HP NonStop (Tandem) 6530-family terminals. **No free
+NonStop emulator exists**, so unlike TN5250 (live IBM i) and TN3270 (Hercules
+MVS), this engine cannot be verified against a real host — the implemented
+subset below is frozen and pinned by `parser.test.ts` / conformance tests, and
+deliberately NOT extended speculatively.
+
+## What is implemented (conversational + ANSI-ish subset)
+
+- **Controls**: CR, LF (no scroll — block-mode stay-put at the last row), BS,
+  HT (tab to next unprotected field, else 8-column stops), FF (clear), BEL/NUL
+  ignored; printable ASCII + high-bit bytes pass through (latin1).
+- **Cursor addressing**: `ESC [ row ; col H` (1-based CUP).
+- **Erase**: `ESC [ 0/1/2 J`, `ESC [ K`, plus HP short forms `ESC J` (clear to
+  end of screen) and `ESC K` (clear to end of line).
+- **Display attributes**: `ESC & d <code>` with codes `@` normal, `B` half
+  bright, `D` underline, `H` blink, `J` inverse, `L` underline+inverse.
+- **Protection / fields**: `ESC )` starts a protected span, `ESC (` ends it;
+  input fields are derived as the unprotected gaps between protected spans
+  (`screen.buildFields()`); typing marks the containing field modified.
+- **Block-mode reply**: action keys (ENTER / F1–F16 / SF1–SF16) transmit the
+  modified unprotected fields (HT-separated, trailing blanks trimmed) followed
+  by the key's `ESC p..w` / `` ESC ` ..g `` sequence.
+
+## Known gaps (deliberate)
+
+Native 6530 block-mode specifics from the 6530 Programmer's Guide are absent:
+6530-specific cursor addressing, ETX/EOT block terminators, DC1 read triggers,
+page-mode field definition sequences, status-line protocol. If a real NonStop
+integration ever materializes, extend from captures — not from the manual
+alone — and lift the conformance tests with it.

--- a/packages/proxy/src/hp6530/parser.test.ts
+++ b/packages/proxy/src/hp6530/parser.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect } from 'vitest';
+import { HP6530Screen } from './screen.js';
+import { HP6530Parser } from './parser.js';
+import { HP6530Encoder } from './encoder.js';
+import { ATTR, KEY_TO_SEQUENCE } from './constants.js';
+
+// Conformance pins for the FROZEN HP6530 subset (see README.md — no NonStop
+// emulator exists to verify against, so the implemented behavior is the spec).
+
+function setup() {
+  const screen = new HP6530Screen();
+  const parser = new HP6530Parser(screen);
+  const encoder = new HP6530Encoder(screen);
+  const feed = (text: string) => parser.parse(Buffer.from(text, 'latin1'));
+  return { screen, parser, encoder, feed };
+}
+
+function row(screen: HP6530Screen, r: number): string {
+  const start = r * screen.cols;
+  return screen.buffer.slice(start, start + screen.cols).join('');
+}
+
+describe('HP6530 controls and addressing', () => {
+  it('prints ASCII with cursor advance and honors CR/LF/BS', () => {
+    const { screen, feed } = setup();
+    feed('AB\rC');
+    expect(row(screen, 0).slice(0, 2)).toBe('CB'); // CR rewound to col 0
+    feed('\nX');
+    expect(screen.getChar(1, 1)).toBe('X'); // LF moved down, col kept
+    feed('\b\bY');
+    expect(screen.getChar(1, 0)).toBe('Y'); // BS moved left (with the write advancing after)
+  });
+
+  it('LF at the bottom row stays put (block mode — no scroll)', () => {
+    const { screen, feed } = setup();
+    feed('\x1b[24;1H'); // last row (24 rows)
+    feed('\n');
+    expect(screen.cursorRow).toBe(screen.rows - 1);
+  });
+
+  it('CSI H addresses 1-based row;col', () => {
+    const { screen, feed } = setup();
+    feed('\x1b[5;10HZ');
+    expect(screen.getChar(4, 9)).toBe('Z');
+  });
+
+  it('FF and CSI 2J clear the screen; CSI 0J/1J split at the cursor', () => {
+    const { screen, feed } = setup();
+    feed('\x1b[1;1HAAAA\x1b[2;1HBBBB');
+    feed('\x1b[1;3H\x1b[0J'); // clear from (0,2) to end
+    expect(row(screen, 0).trimEnd()).toBe('AA');
+    expect(row(screen, 1).trim()).toBe('');
+    feed('\x1b[1;1HCCCC\x1b[1;3H\x1b[1J'); // clear from start through cursor
+    expect(row(screen, 0).trimEnd().startsWith('C')).toBe(false);
+  });
+
+  it('HP short-form ESC J / ESC K erase like their CSI forms', () => {
+    const { screen, feed } = setup();
+    feed('\x1b[1;1HHELLO WORLD');
+    feed('\x1b[1;6H\x1bK');
+    expect(row(screen, 0).trimEnd()).toBe('HELLO');
+    feed('\x1b[1;1H\x1bJ');
+    expect(row(screen, 0).trim()).toBe('');
+  });
+});
+
+describe('HP6530 attributes (ESC & d <code>)', () => {
+  it('applies each documented attribute code to subsequent characters', () => {
+    const { screen, feed } = setup();
+    feed('\x1b&dJX'); // inverse
+    expect(screen.attrs[0].inverse).toBe(true);
+    feed('\x1b&dDY'); // underline
+    expect(screen.attrs[1].underline).toBe(true);
+    expect(screen.attrs[1].inverse).toBe(false); // codes replace, not stack
+    feed('\x1b&dBZ'); // half bright
+    expect(screen.attrs[2].halfBright).toBe(true);
+    feed('\x1b&dHW'); // blink
+    expect(screen.attrs[3].blink).toBe(true);
+    feed('\x1b&dLV'); // underline + inverse
+    expect(screen.attrs[4].underline).toBe(true);
+    expect(screen.attrs[4].inverse).toBe(true);
+    feed('\x1b&d@N'); // normal resets
+    expect(screen.attrs[5]).toEqual({ halfBright: false, underline: false, blink: false, inverse: false });
+  });
+});
+
+describe('HP6530 protected fields and block mode', () => {
+  function paintForm(feed: (t: string) => boolean) {
+    // "NAME: [input........]" — protected label, unprotected input span
+    feed('\x1b[1;1H\x1b)NAME: \x1b(');
+    feed('\x1b[1;20H\x1b)END\x1b('); // protected span closes the input field
+  }
+
+  it('ESC ) / ESC ( derive input fields from unprotected gaps', () => {
+    const { screen, feed } = setup();
+    paintForm(feed);
+    const inputs = screen.fields.filter((f) => !f.isProtected);
+    expect(inputs.length).toBeGreaterThan(0);
+    const f = inputs.find((x) => x.row === 0 && x.col >= 6);
+    expect(f).toBeDefined();
+  });
+
+  it('HT tabs to the next unprotected field', () => {
+    const { screen, feed } = setup();
+    paintForm(feed);
+    screen.setCursor(0, 0);
+    feed('\t');
+    const first = screen.fields.filter((f) => !f.isProtected)[0];
+    expect(screen.cursorRow).toBe(first.row);
+    expect(screen.cursorCol).toBe(first.col);
+  });
+
+  it('typed fields transmit on action keys with the F-key sequence appended', () => {
+    const { screen, feed, encoder } = setup();
+    paintForm(feed);
+    const input = screen.fields.filter((f) => !f.isProtected)[0];
+    screen.setCursor(input.row, input.col);
+    expect(encoder.insertText('SMITH')).toBe(true);
+
+    const wire = encoder.buildKeyResponse('F1')!;
+    const text = wire.toString('latin1');
+    expect(text).toContain('SMITH');
+    expect(text).toContain(KEY_TO_SEQUENCE['F1'].toString('latin1'));
+  });
+
+  it('typing into a protected span is refused', () => {
+    const { screen, feed, encoder } = setup();
+    paintForm(feed);
+    screen.setCursor(0, 0); // inside the protected label
+    expect(encoder.insertText('nope')).toBe(false);
+  });
+
+  it('unknown keys return null from the encoder', () => {
+    const { encoder } = setup();
+    expect(encoder.buildKeyResponse('NotAKey')).toBeNull();
+  });
+});
+
+describe('HP6530 F-key sequence table pins', () => {
+  it('F1-F8 use ESC p..w and F9-F16 use ESC `..g', () => {
+    expect(KEY_TO_SEQUENCE['F1']).toEqual(Buffer.from([0x1b, 0x70]));
+    expect(KEY_TO_SEQUENCE['F8']).toEqual(Buffer.from([0x1b, 0x77]));
+    expect(KEY_TO_SEQUENCE['F9']).toEqual(Buffer.from([0x1b, 0x60]));
+    expect(KEY_TO_SEQUENCE['F16']).toEqual(Buffer.from([0x1b, 0x67]));
+  });
+
+  it('attribute code table matches the documented HP codes', () => {
+    expect(ATTR.NORMAL).toBe(0x40);
+    expect(ATTR.INVERSE).toBe(0x4a);
+    expect(ATTR.UNDERLINE).toBe(0x44);
+  });
+});

--- a/packages/proxy/src/protocols/tn3270-handler.ts
+++ b/packages/proxy/src/protocols/tn3270-handler.ts
@@ -83,9 +83,31 @@ export class TN3270Handler extends ProtocolHandler {
     this.removeAllListeners();
   }
 
+  /**
+   * Answer host-initiated reads the parser flagged — Read Partition
+   * (Query) and Read Buffer / Read Modified (All). Without these replies
+   * the host waits forever (same flush pattern as the 5250 handler).
+   */
+  private flushHostReplies(): void {
+    if (this.parser.pendingQueryReply) {
+      this.parser.pendingQueryReply = false;
+      this.connection.sendRaw(this.encoder.buildQueryReply());
+    }
+    if (this.parser.pendingRead) {
+      const kind = this.parser.pendingRead;
+      this.parser.pendingRead = null;
+      if (kind === 'buffer') {
+        this.connection.sendRaw(this.encoder.buildReadBufferReply());
+      } else {
+        this.connection.sendRaw(this.encoder.buildReadModifiedReply(kind === 'modifiedAll'));
+      }
+    }
+  }
+
   private onRecord(record: Buffer): void {
     try {
       const modified = this.parser.parseRecord(record);
+      this.flushHostReplies();
       if (modified) {
         this.emit('screenChange', this.screen.toScreenData());
       }

--- a/packages/proxy/src/protocols/tn3270-handler.ts
+++ b/packages/proxy/src/protocols/tn3270-handler.ts
@@ -4,6 +4,7 @@ import { TN3270Connection } from '../tn3270/connection.js';
 import { ScreenBuffer3270 } from '../tn3270/screen.js';
 import { TN3270Parser } from '../tn3270/parser.js';
 import { TN3270Encoder } from '../tn3270/encoder.js';
+import { KEY_TO_AID } from '../tn3270/constants.js';
 
 /**
  * TN3270 protocol handler — implements the ProtocolHandler interface
@@ -34,6 +35,10 @@ export class TN3270Handler extends ProtocolHandler {
   }
 
   async connect(host: string, port: number, options?: ProtocolOptions): Promise<void> {
+    // Drop any state left from a previous session on this handler — an
+    // in-place reconnect must not render the pre-drop screen (same
+    // rationale as the 5250 reconnect-reset).
+    this.screen.reset();
     const connectTimeout = options?.connectTimeout as number | undefined;
     await this.connection.connect(host, port, connectTimeout);
   }
@@ -54,6 +59,10 @@ export class TN3270Handler extends ProtocolHandler {
     const response = this.encoder.buildAidResponse(keyName);
     if (!response) return false;
     this.connection.sendRaw(response);
+    // Transmitting an AID inhibits input until the host's WCC keyboard
+    // restore; remember the AID for host-initiated Read Modified replies.
+    this.screen.keyboardLocked = true;
+    this.screen.lastAid = KEY_TO_AID[keyName] ?? this.screen.lastAid;
     return true;
   }
 

--- a/packages/proxy/src/protocols/tn3270-handler.ts
+++ b/packages/proxy/src/protocols/tn3270-handler.ts
@@ -4,7 +4,8 @@ import { TN3270Connection } from '../tn3270/connection.js';
 import { ScreenBuffer3270 } from '../tn3270/screen.js';
 import { TN3270Parser } from '../tn3270/parser.js';
 import { TN3270Encoder } from '../tn3270/encoder.js';
-import { KEY_TO_AID } from '../tn3270/constants.js';
+import { KEY_TO_AID, TERMINAL_TYPE, dimensionsFor3270Type } from '../tn3270/constants.js';
+import type { EbcdicCodePage } from '../encoding/ebcdic.js';
 
 /**
  * TN3270 protocol handler — implements the ProtocolHandler interface
@@ -39,8 +40,19 @@ export class TN3270Handler extends ProtocolHandler {
     // in-place reconnect must not render the pre-drop screen (same
     // rationale as the 5250 reconnect-reset).
     this.screen.reset();
-    const connectTimeout = options?.connectTimeout as number | undefined;
-    await this.connection.connect(host, port, connectTimeout);
+
+    const termType = options?.terminalType || TERMINAL_TYPE;
+    // The model digit sets the ALTERNATE size (EWA); default stays 24x80.
+    const dims = dimensionsFor3270Type(termType);
+    this.screen.configureSizes(dims.rows, dims.cols);
+    // z/OS commonly runs cp37 or cp1047; explicit option wins.
+    this.screen.codePage = (options?.codePage as EbcdicCodePage) ?? 'cp37';
+
+    await this.connection.connect(host, port, {
+      terminalType: termType,
+      connectTimeout: options?.connectTimeout as number | undefined,
+      tn3270e: options?.tn3270e as boolean | undefined,
+    });
   }
 
   disconnect(): void {
@@ -56,9 +68,15 @@ export class TN3270Handler extends ProtocolHandler {
   }
 
   sendKey(keyName: string): boolean {
+    // Liveness probe: application-transparent telnet TIMING-MARK round-trip
+    // (PA/PF keys all reach the application — see connection.sendTimingMark).
+    if (keyName === 'Heartbeat' || keyName === 'HEARTBEAT') {
+      this.connection.sendTimingMark();
+      return true;
+    }
     const response = this.encoder.buildAidResponse(keyName);
     if (!response) return false;
-    this.connection.sendRaw(response);
+    this.connection.sendRecord(response);
     // Transmitting an AID inhibits input until the host's WCC keyboard
     // restore; remember the AID for host-initiated Read Modified replies.
     this.screen.keyboardLocked = true;
@@ -78,6 +96,13 @@ export class TN3270Handler extends ProtocolHandler {
     this.connection.sendRaw(data);
   }
 
+  override getLiveness(): { lastReceivedAtMs: number; lastSentAtMs: number } {
+    return {
+      lastReceivedAtMs: this.connection.lastReceivedAtMs,
+      lastSentAtMs: this.connection.lastSentAtMsValue,
+    };
+  }
+
   destroy(): void {
     this.disconnect();
     this.removeAllListeners();
@@ -91,15 +116,15 @@ export class TN3270Handler extends ProtocolHandler {
   private flushHostReplies(): void {
     if (this.parser.pendingQueryReply) {
       this.parser.pendingQueryReply = false;
-      this.connection.sendRaw(this.encoder.buildQueryReply());
+      this.connection.sendRecord(this.encoder.buildQueryReply());
     }
     if (this.parser.pendingRead) {
       const kind = this.parser.pendingRead;
       this.parser.pendingRead = null;
       if (kind === 'buffer') {
-        this.connection.sendRaw(this.encoder.buildReadBufferReply());
+        this.connection.sendRecord(this.encoder.buildReadBufferReply());
       } else {
-        this.connection.sendRaw(this.encoder.buildReadModifiedReply(kind === 'modifiedAll'));
+        this.connection.sendRecord(this.encoder.buildReadModifiedReply(kind === 'modifiedAll'));
       }
     }
   }

--- a/packages/proxy/src/protocols/tn3270-handler.ts
+++ b/packages/proxy/src/protocols/tn3270-handler.ts
@@ -67,6 +67,27 @@ export class TN3270Handler extends ProtocolHandler {
     return this.encoder.insertText(text);
   }
 
+  override get traits() {
+    return { inputModel: 'block' as const, hasMdt: true };
+  }
+
+  /** 3270 has no 5250 Field-Exit semantics — every other block edit key is local. */
+  override isLocalKey(key: string): boolean {
+    if (/^field.?exit$/i.test(key)) return false;
+    return super.isLocalKey(key);
+  }
+
+  override readFieldValues(modifiedOnly: boolean = true): ReturnType<ProtocolHandler['readFieldValues']> {
+    return this.screen.readFieldValues(modifiedOnly);
+  }
+
+  override eraseEOF(): boolean {
+    const field = this.screen.getFieldAtCursor();
+    if (!field || this.screen.isProtected(field)) return false;
+    this.screen.eraseToFieldEnd(field, this.screen.cursorAddr);
+    return true;
+  }
+
   sendKey(keyName: string): boolean {
     // Liveness probe: application-transparent telnet TIMING-MARK round-trip
     // (PA/PF keys all reach the application — see connection.sendTimingMark).
@@ -74,14 +95,121 @@ export class TN3270Handler extends ProtocolHandler {
       this.connection.sendTimingMark();
       return true;
     }
-    const response = this.encoder.buildAidResponse(keyName);
+
+    const key = TN3270Handler.normalizeKeyName(keyName);
+    if (this.handleLocalKey(key)) return true;
+
+    const response = this.encoder.buildAidResponse(key);
     if (!response) return false;
     this.connection.sendRecord(response);
     // Transmitting an AID inhibits input until the host's WCC keyboard
     // restore; remember the AID for host-initiated Read Modified replies.
     this.screen.keyboardLocked = true;
-    this.screen.lastAid = KEY_TO_AID[keyName] ?? this.screen.lastAid;
+    this.screen.lastAid = KEY_TO_AID[key] ?? this.screen.lastAid;
     return true;
+  }
+
+  /** Local editing keys — mutate the buffer, no host round-trip. */
+  private handleLocalKey(key: string): boolean {
+    switch (key) {
+      case 'ArrowLeft':
+        this.screen.cursorAddr = (this.screen.cursorAddr - 1 + this.screen.size) % this.screen.size;
+        return true;
+      case 'ArrowRight':
+        this.screen.cursorAddr = (this.screen.cursorAddr + 1) % this.screen.size;
+        return true;
+      case 'ArrowUp':
+        this.screen.cursorAddr = (this.screen.cursorAddr - this.screen.cols + this.screen.size) % this.screen.size;
+        return true;
+      case 'ArrowDown':
+        this.screen.cursorAddr = (this.screen.cursorAddr + this.screen.cols) % this.screen.size;
+        return true;
+      case 'Tab':
+      case 'Backtab':
+        return this.tabToField(key === 'Tab' ? 1 : -1);
+      case 'Home': {
+        // 3270 Home = first unprotected field on the screen.
+        const ring = this.screen.inputFieldsInOrder();
+        if (ring.length > 0) this.screen.cursorAddr = ring[0].startAddr;
+        return true;
+      }
+      case 'End': {
+        const field = this.screen.getFieldAtCursor();
+        if (field && !this.screen.isProtected(field)) {
+          const value = this.screen.getFieldValue(field);
+          const dataLen = value.replace(/[\s]+$/, '').length;
+          const idx = Math.min(dataLen, field.length - 1);
+          this.screen.cursorAddr = (field.startAddr + idx) % this.screen.size;
+        }
+        return true;
+      }
+      case 'Backspace': {
+        const field = this.screen.getFieldAtCursor();
+        if (!field || this.screen.isProtected(field)) return true;
+        const idx = this.screen.offsetInField(field, this.screen.cursorAddr);
+        if (idx <= 0) return true; // at field start — nowhere to go
+        this.screen.cursorAddr = (this.screen.cursorAddr - 1 + this.screen.size) % this.screen.size;
+        this.screen.deleteCharAt(field, this.screen.cursorAddr);
+        return true;
+      }
+      case 'Delete': {
+        const field = this.screen.getFieldAtCursor();
+        if (!field || this.screen.isProtected(field)) return true;
+        this.screen.deleteCharAt(field, this.screen.cursorAddr);
+        return true;
+      }
+      case 'Insert':
+        this.screen.insertMode = !this.screen.insertMode;
+        return true;
+      case 'Reset':
+        this.screen.keyboardLocked = false;
+        this.screen.insertMode = false;
+        return true;
+      case 'EraseEOF':
+        this.eraseEOF();
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  /** Tab/Backtab: walk unprotected fields in buffer-address order. */
+  private tabToField(direction: 1 | -1): boolean {
+    const ring = this.screen.inputFieldsInOrder();
+    if (ring.length === 0) return false;
+    const cur = this.screen.getFieldAtCursor();
+    const curIdx = cur ? ring.findIndex((f) => f.startAddr === cur.startAddr) : -1;
+    let target: number;
+    if (curIdx === -1) {
+      // Cursor in protected space: Tab goes to the next field after the
+      // cursor address; Backtab to the previous one.
+      const addr = this.screen.cursorAddr;
+      if (direction === 1) {
+        target = ring.findIndex((f) => f.startAddr > addr);
+        if (target === -1) target = 0;
+      } else {
+        const before = ring.filter((f) => f.startAddr < addr);
+        target = before.length > 0 ? ring.indexOf(before[before.length - 1]) : ring.length - 1;
+      }
+    } else {
+      target = (curIdx + direction + ring.length) % ring.length;
+    }
+    this.screen.cursorAddr = ring[target].startAddr;
+    return true;
+  }
+
+  /** Frontend key aliases (uppercase forms) → canonical names. */
+  private static normalizeKeyName(key: string): string {
+    const map: Record<string, string> = {
+      'ENTER': 'Enter', 'TAB': 'Tab', 'BACKTAB': 'Backtab',
+      'PAGEUP': 'PageUp', 'PAGEDOWN': 'PageDown',
+      'BACKSPACE': 'Backspace', 'DELETE': 'Delete',
+      'CLEAR': 'Clear',
+      'UP': 'ArrowUp', 'DOWN': 'ArrowDown', 'LEFT': 'ArrowLeft', 'RIGHT': 'ArrowRight',
+      'HOME': 'Home', 'END': 'End', 'INSERT': 'Insert',
+      'RESET': 'Reset',
+    };
+    return map[key] || key;
   }
 
   setCursor(row: number, col: number): boolean {

--- a/packages/proxy/src/protocols/vt-handler.ts
+++ b/packages/proxy/src/protocols/vt-handler.ts
@@ -46,8 +46,24 @@ export class VTHandler extends ProtocolHandler {
     return this.connection.isConnected;
   }
 
-  async connect(host: string, port: number, _options?: ProtocolOptions): Promise<void> {
-    await this.connection.connect(host, port);
+  async connect(host: string, port: number, options?: ProtocolOptions): Promise<void> {
+    // Drop prior-session state (same reconnect-reset rationale as 5250/3270).
+    this.screen.reset();
+    this.parser.pendingResponses.length = 0;
+
+    const rows = (options?.rows as number) || this.screen.rows;
+    const cols = (options?.cols as number) || this.screen.cols;
+    if (rows !== this.screen.rows || cols !== this.screen.cols) {
+      this.screen.resize(rows, cols);
+    }
+    this.parser.encoding = options?.encoding === 'utf8' ? 'utf8' : 'latin1';
+
+    await this.connection.connect(host, port, {
+      terminalType: options?.terminalType as string | undefined,
+      rows,
+      cols,
+      connectTimeout: options?.connectTimeout as number | undefined,
+    });
   }
 
   disconnect(): void {
@@ -61,6 +77,12 @@ export class VTHandler extends ProtocolHandler {
   sendText(text: string): boolean {
     const encoded = this.encoder.encodeText(text);
     this.connection.sendRaw(encoded);
+    // Line-mode servers (no WILL ECHO) expect the terminal to echo locally —
+    // without this, typed text is invisible until the host redraws.
+    if (!this.connection.remoteEcho) {
+      this.parser.feed(encoded);
+      this.emit('screenChange', this.screen.toScreenData());
+    }
     return true;
   }
 
@@ -68,11 +90,22 @@ export class VTHandler extends ProtocolHandler {
     const encoded = this.encoder.encodeKey(keyName);
     if (!encoded) return false;
     this.connection.sendRaw(encoded);
+    if (!this.connection.remoteEcho && keyName.toUpperCase() === 'ENTER') {
+      this.parser.feed(Buffer.from('\r\n', 'latin1'));
+      this.emit('screenChange', this.screen.toScreenData());
+    }
     return true;
   }
 
   sendRaw(data: Buffer): void {
     this.connection.sendRaw(data);
+  }
+
+  override getLiveness(): { lastReceivedAtMs: number; lastSentAtMs: number } {
+    return {
+      lastReceivedAtMs: this.connection.lastReceivedAtMs,
+      lastSentAtMs: this.connection.lastSentAtMs,
+    };
   }
 
   destroy(): void {
@@ -83,6 +116,11 @@ export class VTHandler extends ProtocolHandler {
   private onData(data: Buffer): void {
     try {
       const modified = this.parser.feed(data);
+      // Answer host probes (DA/DSR/CPR/DECID) — vim/less-style apps hang
+      // without a Cursor Position Report.
+      while (this.parser.pendingResponses.length > 0) {
+        this.connection.sendRaw(this.parser.pendingResponses.shift()!);
+      }
       if (modified) {
         this.emit('screenChange', this.screen.toScreenData());
       }

--- a/packages/proxy/src/tn3270/connection.ts
+++ b/packages/proxy/src/tn3270/connection.ts
@@ -1,32 +1,77 @@
 import * as net from 'net';
 import { EventEmitter } from 'events';
 import { TELNET, TelnetRecordStream } from '../net/telnet.js';
-import { TERMINAL_TYPE } from './constants.js';
+import { TERMINAL_TYPE, TN3270E } from './constants.js';
+
+export interface TN3270ConnectOptions {
+  /** Terminal type / TN3270E device type (e.g. 'IBM-3278-2'). */
+  terminalType?: string;
+  connectTimeout?: number;
+  /**
+   * Negotiate TN3270E (RFC 2355) when the server offers it. Default true;
+   * set false to force classic RFC 1576 (TTYPE + EOR + BINARY).
+   */
+  tn3270e?: boolean;
+}
 
 /**
- * Manages raw TCP socket to a z/OS (or other 3270) host.
- * Handles Telnet negotiation and extracts 3270 data records (IAC EOR delimited).
+ * Manages the raw TCP socket to a z/OS (or other 3270) host: telnet
+ * negotiation, IAC EOR record framing (shared TelnetRecordStream), and the
+ * TN3270E (RFC 2355) session layer — device-type/functions negotiation and
+ * the 5-byte data header on every record in both directions.
  *
- * Supports basic TN3270 (RFC 1576) negotiation.
- * TN3270E (RFC 2355) is handled at a basic level.
+ * Falls back to classic TN3270 (RFC 1576) when the server doesn't offer
+ * option 40 or `tn3270e: false` was requested.
  */
 export class TN3270Connection extends EventEmitter {
   private socket: net.Socket | null = null;
   private host: string = '';
   private port: number = 23;
   private connected: boolean = false;
+  private terminalType: string = TERMINAL_TYPE;
+
+  // --- TN3270E state ---
+  private tn3270eEnabled: boolean = true;
+  private tn3270eMode: boolean = false;       // WILL/DO agreed on option 40
+  private tn3270eNegotiated: boolean = false; // FUNCTIONS IS agreed — headers flow
+  private deviceTypeRequested: string = '';
+  /** Device name (LU) the server assigned via DEVICE-TYPE IS ... CONNECT. */
+  private luName: string = '';
+  private sendSeq: number = 0;
+
+  /** Liveness timestamps — same contract as the TN5250 connection. */
+  private lastRecvAtMs: number = 0;
+  private lastSentAtMs: number = 0;
+
   private readonly stream = new TelnetRecordStream({
     onNegotiation: (cmd, option) => this.handleNegotiation(cmd, option),
     onSubnegotiation: (data) => this.handleSubnegotiation(data),
     onRecord: (record) => this.onRecord(record),
   });
-  private tn3270eMode: boolean = false;
 
   get isConnected(): boolean {
     return this.connected;
   }
 
-  connect(host: string, port: number, connectTimeout?: number): Promise<void> {
+  /** Whether the RFC 2355 session layer is active (5-byte data headers). */
+  get isTn3270e(): boolean {
+    return this.tn3270eNegotiated;
+  }
+
+  /** LU / device name the server bound this session to ('' if none). */
+  get assignedLuName(): string {
+    return this.luName;
+  }
+
+  get lastReceivedAtMs(): number {
+    return this.lastRecvAtMs;
+  }
+
+  get lastSentAtMsValue(): number {
+    return this.lastSentAtMs;
+  }
+
+  connect(host: string, port: number, options?: TN3270ConnectOptions): Promise<void> {
     return new Promise((resolve, reject) => {
       if (this.socket) {
         this.disconnect();
@@ -35,10 +80,16 @@ export class TN3270Connection extends EventEmitter {
       this.host = host;
       this.port = port;
       this.stream.reset();
+      this.tn3270eEnabled = options?.tn3270e !== false;
       this.tn3270eMode = false;
+      this.tn3270eNegotiated = false;
+      this.terminalType = options?.terminalType || TERMINAL_TYPE;
+      this.deviceTypeRequested = '';
+      this.luName = '';
+      this.sendSeq = 0;
 
       this.socket = new net.Socket();
-      this.socket.setTimeout(connectTimeout ?? 30000);
+      this.socket.setTimeout(options?.connectTimeout ?? 30000);
 
       const onError = (err: Error) => {
         this.cleanup();
@@ -49,7 +100,9 @@ export class TN3270Connection extends EventEmitter {
 
       this.socket.connect(port, host, () => {
         this.connected = true;
+        this.lastRecvAtMs = Date.now();
         this.socket!.removeListener('error', onError);
+        try { this.socket!.setKeepAlive(true, 30_000); } catch { /* ignore */ }
 
         this.socket!.on('error', (err) => {
           this.emit('error', err);
@@ -85,8 +138,42 @@ export class TN3270Connection extends EventEmitter {
 
   sendRaw(data: Buffer): void {
     if (this.socket && this.connected) {
+      this.lastSentAtMs = Date.now();
       this.socket.write(data);
     }
+  }
+
+  /**
+   * Send one 3270 record: prepends the TN3270E 5-byte header when the
+   * session layer is active, escapes IAC bytes, appends IAC EOR.
+   */
+  sendRecord(record: Buffer): void {
+    let payload = record;
+    if (this.tn3270eNegotiated) {
+      const header = Buffer.from([
+        TN3270E.DT_3270_DATA, 0x00, 0x00,
+        (this.sendSeq >> 8) & 0x7f, this.sendSeq & 0xff,
+      ]);
+      this.sendSeq = (this.sendSeq + 1) & 0x7fff;
+      payload = Buffer.concat([header, record]);
+    }
+    const framed: number[] = [];
+    for (const byte of payload) {
+      framed.push(byte);
+      if (byte === TELNET.IAC) framed.push(TELNET.IAC);
+    }
+    framed.push(TELNET.IAC, TELNET.EOR);
+    this.sendRaw(Buffer.from(framed));
+  }
+
+  /**
+   * Telnet TIMING-MARK probe — an application-transparent liveness
+   * round-trip (the server must answer WILL/WONT TM). The 3270 analog of
+   * the 5250 'Heartbeat': PA/PF keys all reach the application, so a probe
+   * must stay at the telnet layer.
+   */
+  sendTimingMark(): void {
+    this.sendRaw(Buffer.from([TELNET.IAC, TELNET.DO, TELNET.OPT_TIMING_MARK]));
   }
 
   private cleanup(): void {
@@ -99,33 +186,47 @@ export class TN3270Connection extends EventEmitter {
   }
 
   private onData(data: Buffer): void {
+    // Any byte from the host is liveness proof — stamp before parsing.
+    this.lastRecvAtMs = Date.now();
     this.stream.feed(data);
   }
 
   private onRecord(record: Buffer): void {
-    // In TN3270E mode, strip the 5-byte header (proper RFC 2355 header
-    // handling lands with the TN3270E negotiation rework).
-    if (this.tn3270eMode && record.length > 5) {
-      const dataRecord = record.subarray(5);
-      if (dataRecord.length > 0) {
-        this.emit('data', dataRecord);
-      }
-    } else {
-      this.emit('data', record);
+    if (!this.tn3270eNegotiated) {
+      if (record.length > 0) this.emit('data', record);
+      return;
+    }
+    // TN3270E: every record carries the 5-byte header.
+    if (record.length < 5) return;
+    const dataType = record[0];
+    const payload = record.subarray(5);
+    switch (dataType) {
+      case TN3270E.DT_3270_DATA:
+      case TN3270E.DT_SSCP_LU_DATA:
+        // SSCP-LU data (VTAM USSMSG screens) is an unformatted stream —
+        // the parser's command-less fallback renders it.
+        if (payload.length > 0) this.emit('data', payload);
+        break;
+      case TN3270E.DT_UNBIND:
+        this.emit('unbind');
+        break;
+      default:
+        // RESPONSE / BIND-IMAGE / NVT etc. — we negotiated no functions,
+        // so these should not arrive; ignore defensively.
+        break;
     }
   }
 
   private handleNegotiation(cmd: number, option: number): void {
     switch (cmd) {
       case TELNET.DO:
-        if (option === TELNET.OPT_TTYPE ||
+        if (option === TELNET.OPT_TN3270E && this.tn3270eEnabled) {
+          this.sendTelnet(TELNET.WILL, option);
+          this.tn3270eMode = true;
+        } else if (option === TELNET.OPT_TTYPE ||
             option === TELNET.OPT_EOR ||
             option === TELNET.OPT_BINARY) {
           this.sendTelnet(TELNET.WILL, option);
-        } else if (option === 0x28) {
-          // TN3270E — accept
-          this.sendTelnet(TELNET.WILL, option);
-          this.tn3270eMode = true;
         } else {
           this.sendTelnet(TELNET.WONT, option);
         }
@@ -135,20 +236,31 @@ export class TN3270Connection extends EventEmitter {
         if (option === TELNET.OPT_EOR ||
             option === TELNET.OPT_BINARY) {
           this.sendTelnet(TELNET.DO, option);
-        } else if (option === 0x28) {
+        } else if (option === TELNET.OPT_TN3270E && this.tn3270eEnabled) {
           this.sendTelnet(TELNET.DO, option);
           this.tn3270eMode = true;
+        } else if (option === TELNET.OPT_TIMING_MARK) {
+          // Reply to our liveness probe — the timestamp update in onData
+          // is the signal; no further reply needed (RFC 860).
         } else {
           this.sendTelnet(TELNET.DONT, option);
         }
         break;
 
       case TELNET.DONT:
+        if (option === TELNET.OPT_TN3270E) {
+          this.tn3270eMode = false;
+          this.tn3270eNegotiated = false;
+        }
         this.sendTelnet(TELNET.WONT, option);
         break;
 
       case TELNET.WONT:
-        this.sendTelnet(TELNET.DONT, option);
+        if (option === TELNET.OPT_TIMING_MARK) {
+          // Server declined the probe — still liveness proof, nothing to do.
+        } else {
+          this.sendTelnet(TELNET.DONT, option);
+        }
         break;
     }
   }
@@ -160,14 +272,13 @@ export class TN3270Connection extends EventEmitter {
 
     if (option === TELNET.OPT_TTYPE && data.length >= 2 && data[1] === TELNET.TTYPE_SEND) {
       this.sendTerminalType();
-    } else if (option === 0x28) {
-      // TN3270E subnegotiation
+    } else if (option === TELNET.OPT_TN3270E) {
       this.handleTN3270ESubneg(data);
     }
   }
 
   private sendTerminalType(): void {
-    const typeStr = TERMINAL_TYPE;
+    const typeStr = this.terminalType;
     const buf = Buffer.alloc(4 + typeStr.length + 2);
     let i = 0;
     buf[i++] = TELNET.IAC;
@@ -182,36 +293,96 @@ export class TN3270Connection extends EventEmitter {
     this.sendRaw(buf);
   }
 
+  /**
+   * RFC 2355 subnegotiation. `data` = [0x28, <byte1>, <byte2>, ...] where
+   * server-initiated messages are SEND DEVICE-TYPE [0x08 0x02],
+   * DEVICE-TYPE IS/REJECT [0x02 0x04|0x06 ...], FUNCTIONS REQUEST/IS
+   * [0x03 0x07|0x04 ...].
+   */
   private handleTN3270ESubneg(data: Buffer): void {
-    if (data.length < 2) return;
+    if (data.length < 3) return;
+    const kind = data[1];
+    const op = data[2];
 
-    const msgType = data[1];
-    // TN3270E DEVICE-TYPE SEND (0x08 0x02)
-    if (msgType === 0x02) {
-      // Send device type response
-      const typeStr = TERMINAL_TYPE;
-      const resp = Buffer.alloc(4 + typeStr.length + 2);
-      let i = 0;
-      resp[i++] = TELNET.IAC;
-      resp[i++] = TELNET.SB;
-      resp[i++] = 0x28; // TN3270E
-      resp[i++] = 0x02; // DEVICE-TYPE IS
-      for (let j = 0; j < typeStr.length; j++) {
-        resp[i++] = typeStr.charCodeAt(j);
+    if (kind === TN3270E.SEND && op === TN3270E.DEVICE_TYPE) {
+      // Server: SEND DEVICE-TYPE → we REQUEST our device type (-E variant
+      // for extended datastream unless the caller pinned one).
+      this.deviceTypeRequested = this.terminalType.endsWith('-E')
+        ? this.terminalType
+        : `${this.terminalType}-E`;
+      this.sendDeviceTypeRequest(this.deviceTypeRequested);
+      return;
+    }
+
+    if (kind === TN3270E.DEVICE_TYPE) {
+      this.handleDeviceTypeReply(op, data);
+      return;
+    }
+
+    if (kind === TN3270E.FUNCTIONS) {
+      this.handleFunctionsReply(op, data);
+    }
+  }
+
+  private handleDeviceTypeReply(op: number, data: Buffer): void {
+    if (op === TN3270E.IS) {
+      // DEVICE-TYPE IS <type> [CONNECT <lu>] — accepted. Extract the LU.
+      const rest = data.subarray(3).toString('latin1');
+      const connectIdx = rest.indexOf(String.fromCharCode(TN3270E.CONNECT));
+      if (connectIdx >= 0) {
+        this.luName = rest.substring(connectIdx + 1);
       }
-      resp[i++] = TELNET.IAC;
-      resp[i++] = TELNET.SE;
-      this.sendRaw(resp);
+      // Propose the empty function set (plain terminal semantics).
+      this.sendFunctions(TN3270E.REQUEST, []);
+      return;
     }
-    // TN3270E FUNCTIONS REQUEST (0x08 0x04)
-    if (msgType === 0x04) {
-      // Accept no functions
-      this.sendRaw(Buffer.from([
-        TELNET.IAC, TELNET.SB, 0x28,
-        0x04, // FUNCTIONS IS
-        TELNET.IAC, TELNET.SE,
-      ]));
+    if (op === TN3270E.REJECT) {
+      if (this.deviceTypeRequested.endsWith('-E')) {
+        // Retry once without extended datastream.
+        this.deviceTypeRequested = this.deviceTypeRequested.slice(0, -2);
+        this.sendDeviceTypeRequest(this.deviceTypeRequested);
+      } else {
+        this.emit('error', new Error(
+          `TN3270E device type rejected by host (${this.terminalType})`));
+      }
     }
+  }
+
+  private handleFunctionsReply(op: number, data: Buffer): void {
+    const requested = [...data.subarray(3)];
+    if (op === TN3270E.IS) {
+      // Agreement — with our empty proposal this should be the empty set.
+      this.tn3270eNegotiated = true;
+      return;
+    }
+    if (op === TN3270E.REQUEST) {
+      if (requested.length === 0) {
+        // Server proposes the empty set too — agree and go live.
+        this.sendFunctions(TN3270E.IS, []);
+        this.tn3270eNegotiated = true;
+      } else {
+        // Server wants functions we don't implement — counter with empty.
+        this.sendFunctions(TN3270E.REQUEST, []);
+      }
+    }
+  }
+
+  private sendDeviceTypeRequest(deviceType: string): void {
+    const parts: number[] = [
+      TELNET.IAC, TELNET.SB, TELNET.OPT_TN3270E,
+      TN3270E.DEVICE_TYPE, TN3270E.REQUEST,
+    ];
+    for (let i = 0; i < deviceType.length; i++) parts.push(deviceType.charCodeAt(i));
+    parts.push(TELNET.IAC, TELNET.SE);
+    this.sendRaw(Buffer.from(parts));
+  }
+
+  private sendFunctions(op: number, functions: number[]): void {
+    this.sendRaw(Buffer.from([
+      TELNET.IAC, TELNET.SB, TELNET.OPT_TN3270E,
+      TN3270E.FUNCTIONS, op, ...functions,
+      TELNET.IAC, TELNET.SE,
+    ]));
   }
 
   private sendTelnet(cmd: number, option: number): void {

--- a/packages/proxy/src/tn3270/constants.ts
+++ b/packages/proxy/src/tn3270/constants.ts
@@ -202,6 +202,21 @@ export const SCREEN3270 = {
   MODEL5_COLS: 132,
 } as const;
 
+/**
+ * Screen dimensions for a 3278/3279 terminal-type string. The model digit
+ * (2-5) selects the ALTERNATE size (Erase/Write Alternate); the default
+ * size is always Model 2's 24x80.
+ */
+export function dimensionsFor3270Type(terminalType: string): { rows: number; cols: number } {
+  const m = /^IBM-327[89]-([2-5])(?:-E)?$/i.exec(terminalType.trim());
+  switch (m?.[1]) {
+    case '3': return { rows: SCREEN3270.MODEL3_ROWS, cols: SCREEN3270.MODEL3_COLS };
+    case '4': return { rows: SCREEN3270.MODEL4_ROWS, cols: SCREEN3270.MODEL4_COLS };
+    case '5': return { rows: SCREEN3270.MODEL5_ROWS, cols: SCREEN3270.MODEL5_COLS };
+    default:  return { rows: SCREEN3270.MODEL2_ROWS, cols: SCREEN3270.MODEL2_COLS };
+  }
+}
+
 // Terminal type strings
 export const TERMINAL_TYPE_3270 = 'IBM-3278-2';          // Model 2 (24x80)
 export const TERMINAL_TYPE_3270_M3 = 'IBM-3278-3';       // Model 3 (32x80)
@@ -237,7 +252,13 @@ export const FA = {
 } as const;
 export const EXT_ATTR = EXTENDED_ATTR;
 export const decodeAddress = decodeBufferAddress;
-export function encodeAddress(addr: number, _screenSize: number): Buffer {
+export function encodeAddress(addr: number, screenSize: number): Buffer {
+  // 12-bit encoding addresses at most 4096 positions; larger screens
+  // (none of the standard models, but future partitions) need 14-bit.
+  if (addr > 0x0FFF || screenSize > 0x1000) {
+    const [b1, b2] = encodeBufferAddress14(addr);
+    return Buffer.from([b1, b2]);
+  }
   const [b1, b2] = encodeBufferAddress12(addr);
   return Buffer.from([b1, b2]);
 }

--- a/packages/proxy/src/tn3270/constants.ts
+++ b/packages/proxy/src/tn3270/constants.ts
@@ -1,6 +1,5 @@
-// === Telnet Constants (shared with TN5250) ===
+// === Telnet Constants (shared across protocols) ===
 export { TELNET } from '../net/telnet.js';
-import { TELNET } from '../net/telnet.js';
 
 // === 3270 Command Codes ===
 export const CMD3270 = {
@@ -38,12 +37,14 @@ export const ORDER3270 = {
 } as const;
 
 // === WCC (Write Control Character) bits ===
+// Per GA23-0059 (and x3270 ctlr.c): the previous table here had RESET_MDT
+// and the keyboard bit wrong — keyboard restore is 0x02, reset-MDT is 0x01.
 export const WCC = {
-  RESET_MDT: 0x02,           // Reset Modified Data Tags
-  RESET_KEYBOARD: 0x40,      // Reset keyboard lock
-  SOUND_ALARM: 0x04,         // Sound audible alarm
-  RESET_PARTITION: 0x01,     // Reset partition characteristics
+  RESET: 0x40,               // Reset partition characteristics
   START_PRINTER: 0x08,       // Start printer
+  SOUND_ALARM: 0x04,         // Sound audible alarm
+  KEYBOARD_RESTORE: 0x02,    // Unlock keyboard + reset AID
+  RESET_MDT: 0x01,           // Reset Modified Data Tags
 } as const;
 
 // === 3270 AID (Attention Identifier) bytes ===

--- a/packages/proxy/src/tn3270/encoder.ts
+++ b/packages/proxy/src/tn3270/encoder.ts
@@ -173,16 +173,41 @@ export class TN3270Encoder {
 
     for (const ch of text) {
       if (cursorAddr === fieldEnd) break;
+      if (this.screen.insertMode) {
+        this.shiftRightFrom(field, cursorAddr);
+      }
       this.screen.setCharAt(cursorAddr, ch, charToEbcdic(ch, this.screen.codePage));
       cursorAddr = (cursorAddr + 1) % this.screen.size;
     }
 
     this.screen.cursorAddr = cursorAddr;
-    field.modified = true;
+    this.screen.markModified(field);
 
-    // Set MDT in the attribute
-    this.screen.attrBuffer[field.attrAddr] |= 0x01;
+    // Autoskip: filling the field lands the cursor on the following
+    // attribute byte; when that field is skip (protected+numeric) — or
+    // simply protected — jump to the next unprotected field like a real
+    // terminal, so form typing flows field to field.
+    if (cursorAddr === fieldEnd && this.screen.attrBuffer[cursorAddr % this.screen.size] !== 0) {
+      const nextAttr = this.screen.attrBuffer[cursorAddr % this.screen.size];
+      if ((nextAttr & 0x20 /* FA.PROTECTED */) !== 0) {
+        const ring = this.screen.inputFieldsInOrder();
+        const next = ring.find((f) => f.startAddr > field.startAddr) ?? ring[0];
+        if (next) this.screen.cursorAddr = next.startAddr;
+      }
+    }
 
     return true;
+  }
+
+  /** Shift field content right one cell from `addr` (insert-mode typing). */
+  private shiftRightFrom(field: { startAddr: number; length: number }, addr: number): void {
+    const size = this.screen.size;
+    const idx = (addr - field.startAddr + size) % size;
+    for (let i = field.length - 1; i > idx; i--) {
+      const dst = (field.startAddr + i) % size;
+      const src = (field.startAddr + i - 1) % size;
+      this.screen.buffer[dst] = this.screen.buffer[src];
+      this.screen.rawBuffer[dst] = this.screen.rawBuffer[src];
+    }
   }
 }

--- a/packages/proxy/src/tn3270/encoder.ts
+++ b/packages/proxy/src/tn3270/encoder.ts
@@ -8,7 +8,7 @@ import { charToEbcdic, EBCDIC_SPACE } from '../encoding/ebcdic.js';
  * for sending back to the z/OS host.
  */
 export class TN3270Encoder {
-  private screen: ScreenBuffer3270;
+  private readonly screen: ScreenBuffer3270;
 
   constructor(screen: ScreenBuffer3270) {
     this.screen = screen;
@@ -22,18 +22,17 @@ export class TN3270Encoder {
     const aidByte = KEY_TO_AID[keyName];
     if (aidByte === undefined) return null;
 
-    const parts: Buffer[] = [];
-
-    // AID byte
-    parts.push(Buffer.from([aidByte]));
-
-    // Cursor address (2 bytes)
-    parts.push(encodeAddress(this.screen.cursorAddr, this.screen.size));
-
-    // For short-read AIDs (PA keys, Clear), no field data
+    // Short-read AIDs (PA keys, Clear) transmit the AID byte ONLY — no
+    // cursor address, no field data (GA23-0059 "short read").
     if (aidByte === AID.PA1 || aidByte === AID.PA2 || aidByte === AID.PA3 || aidByte === AID.CLEAR) {
-      return this.wrapWithEOR(Buffer.concat(parts));
+      return this.wrapWithEOR(Buffer.from([aidByte]));
     }
+
+    // AID byte + cursor address (2 bytes)
+    const parts: Buffer[] = [
+      Buffer.from([aidByte]),
+      encodeAddress(this.screen.cursorAddr, this.screen.size),
+    ];
 
     // Collect modified fields
     for (const field of this.screen.fields) {
@@ -75,10 +74,10 @@ export class TN3270Encoder {
    */
   private wrapWithEOR(data: Buffer): Buffer {
     const escaped: number[] = [];
-    for (let i = 0; i < data.length; i++) {
-      escaped.push(data[i]);
-      if (data[i] === TELNET.IAC) {
-        escaped.push(TELNET.IAC);
+    for (const byte of data) {
+      escaped.push(byte);
+      if (byte === TELNET.IAC) {
+        escaped.push(TELNET.IAC); // escape 0xFF in data
       }
     }
     escaped.push(TELNET.IAC, TELNET.EOR);
@@ -98,7 +97,7 @@ export class TN3270Encoder {
 
     for (const ch of text) {
       if (cursorAddr === fieldEnd) break;
-      this.screen.buffer[cursorAddr] = ch;
+      this.screen.setCharAt(cursorAddr, ch, charToEbcdic(ch));
       cursorAddr = (cursorAddr + 1) % this.screen.size;
     }
 

--- a/packages/proxy/src/tn3270/encoder.ts
+++ b/packages/proxy/src/tn3270/encoder.ts
@@ -21,10 +21,48 @@ export class TN3270Encoder {
   buildAidResponse(keyName: string): Buffer | null {
     const aidByte = KEY_TO_AID[keyName];
     if (aidByte === undefined) return null;
+    return this.buildReadModified(aidByte, false);
+  }
 
+  /**
+   * Reply to a HOST-initiated Read Modified (All). Carries the AID of the
+   * last attention the operator sent (GA23-0059: the AID is not reset by
+   * the read). `all` = Read Modified All — field data is included even
+   * when the last AID was a short-read key.
+   */
+  buildReadModifiedReply(all: boolean): Buffer {
+    return this.buildReadModified(this.screen.lastAid, all);
+  }
+
+  /**
+   * Reply to a HOST-initiated Read Buffer: AID + cursor + the ENTIRE
+   * buffer — SF+attribute at each field-attribute position, raw data
+   * bytes elsewhere (NULs preserved, unlike Read Modified).
+   */
+  buildReadBufferReply(): Buffer {
+    const body: number[] = [this.screen.lastAid];
+    const cursor = encodeAddress(this.screen.cursorAddr, this.screen.size);
+    body.push(cursor[0], cursor[1]);
+    for (let addr = 0; addr < this.screen.size; addr++) {
+      const attr = this.screen.attrBuffer[addr];
+      if (attr !== 0) {
+        body.push(ORDER.SF, attr);
+      } else {
+        body.push(this.screen.rawBuffer[addr]);
+      }
+    }
+    return this.wrapWithEOR(Buffer.from(body));
+  }
+
+  private static isShortReadAid(aid: number): boolean {
+    return aid === AID.PA1 || aid === AID.PA2 || aid === AID.PA3 || aid === AID.CLEAR;
+  }
+
+  private buildReadModified(aidByte: number, forceFields: boolean): Buffer {
     // Short-read AIDs (PA keys, Clear) transmit the AID byte ONLY — no
-    // cursor address, no field data (GA23-0059 "short read").
-    if (aidByte === AID.PA1 || aidByte === AID.PA2 || aidByte === AID.PA3 || aidByte === AID.CLEAR) {
+    // cursor address, no field data (GA23-0059 "short read") — unless the
+    // host explicitly asked for Read Modified All.
+    if (!forceFields && TN3270Encoder.isShortReadAid(aidByte)) {
       return this.wrapWithEOR(Buffer.from([aidByte]));
     }
 
@@ -47,25 +85,82 @@ export class TN3270Encoder {
       sba[2] = addrBuf[1];
       parts.push(sba);
 
-      // Field data in EBCDIC, trimmed
-      const value = this.screen.getFieldValue(field);
-      const ebcdicData = Buffer.alloc(value.length);
-      for (let i = 0; i < value.length; i++) {
-        ebcdicData[i] = charToEbcdic(value[i]);
+      // Field data in EBCDIC — Read Modified omits NULs entirely and we
+      // additionally trim trailing spaces (hosts treat both as absent).
+      const raw: number[] = [];
+      for (let i = 0; i < field.length; i++) {
+        const byte = this.screen.rawBuffer[(field.startAddr + i) % this.screen.size];
+        if (byte !== 0x00) raw.push(byte);
       }
-
-      // Trim trailing EBCDIC spaces
-      let trimLen = ebcdicData.length;
-      while (trimLen > 0 && ebcdicData[trimLen - 1] === EBCDIC_SPACE) {
+      let trimLen = raw.length;
+      while (trimLen > 0 && raw[trimLen - 1] === EBCDIC_SPACE) {
         trimLen--;
       }
-
       if (trimLen > 0) {
-        parts.push(ebcdicData.subarray(0, trimLen));
+        parts.push(Buffer.from(raw.slice(0, trimLen)));
       }
     }
 
     return this.wrapWithEOR(Buffer.concat(parts));
+  }
+
+  /**
+   * Query Reply for WSF Read Partition (Query) — the device-capability
+   * handshake extended hosts run before using color/highlighting.
+   * Conservative set: Summary, Usable Area, Color, Highlighting, Reply
+   * Modes (field mode only — we never emit SFE-format read replies),
+   * Implicit Partition. Character Sets deliberately omitted until a live
+   * host proves it necessary.
+   */
+  buildQueryReply(): Buffer {
+    const w = this.screen.cols;
+    const h = this.screen.rows;
+    const size = this.screen.size;
+
+    const qr = (code: number, payload: number[]): number[] => {
+      const len = payload.length + 4;
+      return [(len >> 8) & 0xff, len & 0xff, 0x81, code, ...payload];
+    };
+
+    const summary = qr(0x80, [0x80, 0x81, 0x86, 0x87, 0x88, 0xa6]);
+    const usableArea = qr(0x81, [
+      0x01, 0x00, // 12/14-bit addressing; no variable cells
+      (w >> 8) & 0xff, w & 0xff,
+      (h >> 8) & 0xff, h & 0xff,
+      0x01, // units: mm
+      0x00, 0x0a, 0x02, 0xe5, // Xr (x3270's distance measurements)
+      0x00, 0x02, 0x00, 0x6f, // Yr
+      0x07, // cell width
+      0x0c, // cell height
+      (size >> 8) & 0xff, size & 0xff,
+    ]);
+    const color = qr(0x86, [
+      0x00, 0x08, // flags, 8 pairs
+      0x00, 0xf4, // default -> green
+      0xf1, 0xf1, 0xf2, 0xf2, 0xf3, 0xf3, 0xf4, 0xf4,
+      0xf5, 0xf5, 0xf6, 0xf6, 0xf7, 0xf7,
+    ]);
+    const highlighting = qr(0x87, [
+      0x04, // 4 pairs
+      0x00, 0xf0, // default -> normal
+      0xf1, 0xf1, // blink
+      0xf2, 0xf2, // reverse
+      0xf4, 0xf4, // underscore
+    ]);
+    const replyModes = qr(0x88, [0x00]); // field mode only
+    const implicitPartition = qr(0xa6, [
+      0x00, 0x00, // flags
+      0x0b, 0x01, 0x00, // self-defining: length, type, flags
+      (w >> 8) & 0xff, w & 0xff, (h >> 8) & 0xff, h & 0xff, // default size
+      (w >> 8) & 0xff, w & 0xff, (h >> 8) & 0xff, h & 0xff, // alternate size
+    ]);
+
+    return this.wrapWithEOR(
+      Buffer.from([
+        AID.STRUCTURED_FIELD,
+        ...summary, ...usableArea, ...color, ...highlighting, ...replyModes, ...implicitPartition,
+      ]),
+    );
   }
 
   /**

--- a/packages/proxy/src/tn3270/encoder.ts
+++ b/packages/proxy/src/tn3270/encoder.ts
@@ -1,5 +1,4 @@
 import { ScreenBuffer3270 } from './screen.js';
-import { TELNET } from '../net/telnet.js';
 import { KEY_TO_AID, AID, ORDER, encodeAddress } from './constants.js';
 import { charToEbcdic, EBCDIC_SPACE } from '../encoding/ebcdic.js';
 
@@ -16,7 +15,7 @@ export class TN3270Encoder {
 
   /**
    * Build a 3270 Read Modified response for an AID key press.
-   * Format: AID + cursor_addr(2) + [SBA(1) + addr(2) + field_data]... + IAC EOR
+   * Format: AID + cursor_addr(2) + [SBA(1) + addr(2) + field_data]...\n   * Returns the RAW record — the connection adds TN3270E header + EOR framing.
    */
   buildAidResponse(keyName: string): Buffer | null {
     const aidByte = KEY_TO_AID[keyName];
@@ -51,7 +50,7 @@ export class TN3270Encoder {
         body.push(this.screen.rawBuffer[addr]);
       }
     }
-    return this.wrapWithEOR(Buffer.from(body));
+    return Buffer.from(body);
   }
 
   private static isShortReadAid(aid: number): boolean {
@@ -63,7 +62,7 @@ export class TN3270Encoder {
     // cursor address, no field data (GA23-0059 "short read") — unless the
     // host explicitly asked for Read Modified All.
     if (!forceFields && TN3270Encoder.isShortReadAid(aidByte)) {
-      return this.wrapWithEOR(Buffer.from([aidByte]));
+      return Buffer.from([aidByte]);
     }
 
     // AID byte + cursor address (2 bytes)
@@ -101,7 +100,7 @@ export class TN3270Encoder {
       }
     }
 
-    return this.wrapWithEOR(Buffer.concat(parts));
+    return Buffer.concat(parts);
   }
 
   /**
@@ -155,28 +154,10 @@ export class TN3270Encoder {
       (w >> 8) & 0xff, w & 0xff, (h >> 8) & 0xff, h & 0xff, // alternate size
     ]);
 
-    return this.wrapWithEOR(
-      Buffer.from([
-        AID.STRUCTURED_FIELD,
-        ...summary, ...usableArea, ...color, ...highlighting, ...replyModes, ...implicitPartition,
-      ]),
-    );
-  }
-
-  /**
-   * Wrap data with Telnet IAC EOR framing.
-   * Escapes any 0xFF bytes in the data.
-   */
-  private wrapWithEOR(data: Buffer): Buffer {
-    const escaped: number[] = [];
-    for (const byte of data) {
-      escaped.push(byte);
-      if (byte === TELNET.IAC) {
-        escaped.push(TELNET.IAC); // escape 0xFF in data
-      }
-    }
-    escaped.push(TELNET.IAC, TELNET.EOR);
-    return Buffer.from(escaped);
+    return Buffer.from([
+      AID.STRUCTURED_FIELD,
+      ...summary, ...usableArea, ...color, ...highlighting, ...replyModes, ...implicitPartition,
+    ]);
   }
 
   /**
@@ -192,7 +173,7 @@ export class TN3270Encoder {
 
     for (const ch of text) {
       if (cursorAddr === fieldEnd) break;
-      this.screen.setCharAt(cursorAddr, ch, charToEbcdic(ch));
+      this.screen.setCharAt(cursorAddr, ch, charToEbcdic(ch, this.screen.codePage));
       cursorAddr = (cursorAddr + 1) % this.screen.size;
     }
 

--- a/packages/proxy/src/tn3270/host-reads.test.ts
+++ b/packages/proxy/src/tn3270/host-reads.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { TN3270Handler } from '../protocols/tn3270-handler.js';
 import { ScreenBuffer3270 } from './screen.js';
 import { TN3270Parser } from './parser.js';
@@ -57,7 +57,7 @@ describe('host-initiated reads are answered (the host no longer waits forever)',
     sent.length = 0;
 
     feed([CMD.READ_MODIFIED]);
-    expect(sent[0].length).toBe(3); // AID + IAC EOR
+    expect(sent[0].length).toBe(3); // AID + IAC EOR framing
     expect(sent[0][0]).toBe(AID.PA1);
 
     feed([CMD.READ_MODIFIED_ALL]);
@@ -129,9 +129,9 @@ describe('Read Modified field data comes from raw bytes (NUL omission)', () => {
     // Type 2 chars into a field whose remaining cells are erased NULs
     screen.cursorAddr = 10;
     encoder.insertText('AB');
-    const wire = encoder.buildAidResponse('Enter')!;
-    const sbaIdx = wire.indexOf(ORDER.SBA);
-    const dataBytes = [...wire.subarray(sbaIdx + 3, wire.length - 2)];
+    const record = encoder.buildAidResponse('Enter')!;
+    const sbaIdx = record.indexOf(ORDER.SBA);
+    const dataBytes = [...record.subarray(sbaIdx + 3)];
     expect(dataBytes).toEqual(eb('AB')); // no padding spaces, no NULs
     expect(dataBytes).not.toContain(EBCDIC_SPACE);
   });

--- a/packages/proxy/src/tn3270/host-reads.test.ts
+++ b/packages/proxy/src/tn3270/host-reads.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi } from 'vitest';
+import { TN3270Handler } from '../protocols/tn3270-handler.js';
+import { ScreenBuffer3270 } from './screen.js';
+import { TN3270Parser } from './parser.js';
+import { TN3270Encoder } from './encoder.js';
+import { CMD, ORDER, FA, AID, WCC, encodeAddress } from './constants.js';
+import { charToEbcdic, EBCDIC_SPACE } from '../encoding/ebcdic.js';
+
+function eb(text: string): number[] {
+  return [...text].map((c) => charToEbcdic(c));
+}
+
+/** Handler with the connection's sendRaw spied (no real socket). */
+function spiedHandler() {
+  const handler = new TN3270Handler();
+  const sent: Buffer[] = [];
+  (handler.connection as unknown as { sendRaw: (b: Buffer) => void }).sendRaw = (b: Buffer) =>
+    sent.push(b);
+  const feed = (bytes: number[]) =>
+    (handler as unknown as { onRecord: (r: Buffer) => void }).onRecord(Buffer.from(bytes));
+  return { handler, sent, feed };
+}
+
+function paintLogonScreen(feed: (b: number[]) => void, screen: ScreenBuffer3270) {
+  feed([
+    CMD.ERASE_WRITE, WCC.KEYBOARD_RESTORE,
+    ORDER.SBA, ...encodeAddress(2 * 80 + 0, screen.size),
+    ...eb('USERID'),
+    ORDER.SF, 0x40, // unprotected input right after the label
+  ]);
+}
+
+describe('host-initiated reads are answered (the host no longer waits forever)', () => {
+  it('Read Modified replies with lastAid + cursor + modified fields', () => {
+    const { handler, sent, feed } = spiedHandler();
+    paintLogonScreen(feed, handler.screen);
+    handler.screen.cursorAddr = 2 * 80 + 7;
+    handler.sendKey('Enter'); // sets lastAid (goes through the spied sendRaw)
+    handler.encoder.insertText('HERC02');
+    sent.length = 0;
+
+    feed([CMD.READ_MODIFIED]);
+    expect(sent).toHaveLength(1);
+    const reply = sent[0];
+    expect(reply[0]).toBe(AID.ENTER); // AID survives the read
+    // contains the typed text in EBCDIC
+    const hex = reply.toString('hex');
+    expect(hex).toContain(Buffer.from(eb('HERC02')).toString('hex'));
+  });
+
+  it('Read Modified after a short-read AID replies AID-only; Read Modified All includes fields', () => {
+    const { handler, sent, feed } = spiedHandler();
+    paintLogonScreen(feed, handler.screen);
+    handler.screen.cursorAddr = 2 * 80 + 7;
+    handler.encoder.insertText('X');
+    handler.sendKey('PA1');
+    sent.length = 0;
+
+    feed([CMD.READ_MODIFIED]);
+    expect(sent[0].length).toBe(3); // AID + IAC EOR
+    expect(sent[0][0]).toBe(AID.PA1);
+
+    feed([CMD.READ_MODIFIED_ALL]);
+    const rma = sent[1];
+    expect(rma[0]).toBe(AID.PA1);
+    expect(rma.length).toBeGreaterThan(3); // fields included despite short-read AID
+  });
+
+  it('Read Buffer reproduces SF attributes and preserves NULs', () => {
+    const { handler, sent, feed } = spiedHandler();
+    paintLogonScreen(feed, handler.screen);
+    sent.length = 0;
+
+    feed([CMD.READ_BUFFER]);
+    const reply = sent[0];
+    // AID + 2-byte cursor, then the full buffer walk
+    let sfCount = 0;
+    let nulCount = 0;
+    for (let i = 3; i < reply.length - 2; i++) {
+      if (reply[i] === ORDER.SF) {
+        sfCount++;
+        i++; // skip attr byte
+      } else if (reply[i] === 0x00) {
+        nulCount++;
+      }
+    }
+    expect(sfCount).toBe(1); // exactly the one field attribute painted
+    expect(nulCount).toBeGreaterThan(1000); // erased cells stay NUL, not space
+  });
+
+  it('WSF Read Partition Query gets a structurally-valid Query Reply', () => {
+    const { sent, feed } = spiedHandler();
+    feed([CMD.WRITE_STRUCTURED_FIELD, 0x00, 0x05, 0x01, 0xff, 0x02]);
+    expect(sent).toHaveLength(1);
+    const reply = sent[0];
+    expect(reply[0]).toBe(AID.STRUCTURED_FIELD); // 0x88
+
+    // Walk the structured fields: each starts with a 2-byte length that
+    // must land exactly on the next SF; QR class byte is 0x81.
+    const body = reply.subarray(1, reply.length - 2); // strip AID + IAC EOR
+    const codes: number[] = [];
+    let pos = 0;
+    while (pos < body.length) {
+      const len = (body[pos] << 8) | body[pos + 1];
+      expect(len).toBeGreaterThanOrEqual(4);
+      expect(body[pos + 2]).toBe(0x81);
+      codes.push(body[pos + 3]);
+      pos += len;
+    }
+    expect(pos).toBe(body.length); // lengths sum exactly
+    expect(codes[0]).toBe(0x80); // Summary first
+    expect(codes).toContain(0x81); // Usable Area
+    expect(codes).toContain(0xa6); // Implicit Partition
+  });
+});
+
+describe('Read Modified field data comes from raw bytes (NUL omission)', () => {
+  it('omits NUL positions inside the field instead of sending spaces', () => {
+    const screen = new ScreenBuffer3270();
+    const parser = new TN3270Parser(screen);
+    const encoder = new TN3270Encoder(screen);
+    parser.parseRecord(
+      Buffer.from([
+        CMD.ERASE_WRITE, 0x00,
+        ORDER.SBA, ...encodeAddress(9, screen.size),
+        ORDER.SF, 0x40,
+      ]),
+    );
+    // Type 2 chars into a field whose remaining cells are erased NULs
+    screen.cursorAddr = 10;
+    encoder.insertText('AB');
+    const wire = encoder.buildAidResponse('Enter')!;
+    const sbaIdx = wire.indexOf(ORDER.SBA);
+    const dataBytes = [...wire.subarray(sbaIdx + 3, wire.length - 2)];
+    expect(dataBytes).toEqual(eb('AB')); // no padding spaces, no NULs
+    expect(dataBytes).not.toContain(EBCDIC_SPACE);
+  });
+});

--- a/packages/proxy/src/tn3270/interactive-keys.test.ts
+++ b/packages/proxy/src/tn3270/interactive-keys.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from 'vitest';
+import { TN3270Handler } from '../protocols/tn3270-handler.js';
+import { CMD, ORDER, FA, WCC, encodeAddress } from './constants.js';
+import { charToEbcdic } from '../encoding/ebcdic.js';
+
+function eb(text: string): number[] {
+  return [...text].map((c) => charToEbcdic(c));
+}
+
+/**
+ * Handler with a painted two-field form (no socket):
+ *   row 2: NAME: [8-char input]      row 4: QTY: [5-char numeric input]
+ */
+function formHandler() {
+  const handler = new TN3270Handler();
+  (handler.connection as unknown as { sendRaw: (b: Buffer) => void }).sendRaw = () => {};
+  const screen = handler.screen;
+  handler.parser.parseRecord(
+    Buffer.from([
+      CMD.ERASE_WRITE, WCC.KEYBOARD_RESTORE,
+      ORDER.SBA, ...encodeAddress(2 * 80 + 0, screen.size), ...eb('NAME:'),
+      ORDER.SF, 0x40, // input field starts at (2,6)
+      ORDER.SBA, ...encodeAddress(2 * 80 + 14, screen.size),
+      ORDER.SF, 0x40 | FA.PROTECTED, // terminates the name field (len 8)
+      ORDER.SBA, ...encodeAddress(4 * 80 + 0, screen.size), ...eb('QTY:'),
+      ORDER.SF, 0x40 | FA.NUMERIC, // numeric input at (4,5)
+      ORDER.SBA, ...encodeAddress(4 * 80 + 10, screen.size),
+      ORDER.SF, 0x40 | FA.PROTECTED,
+    ]),
+  );
+  return { handler, screen };
+}
+
+const NAME_START = 2 * 80 + 6;
+const QTY_START = 4 * 80 + 5; // 'QTY:' is 4 chars, attr at +4, field at +5
+
+describe('TN3270 local editing keys', () => {
+  it('Tab/Backtab walk the unprotected-field ring', () => {
+    const { handler, screen } = formHandler();
+    screen.cursorAddr = NAME_START;
+    handler.sendKey('Tab');
+    expect(screen.cursorAddr).toBe(QTY_START);
+    handler.sendKey('Tab'); // wraps
+    expect(screen.cursorAddr).toBe(NAME_START);
+    handler.sendKey('Backtab');
+    expect(screen.cursorAddr).toBe(QTY_START);
+  });
+
+  it('Tab from protected space goes to the next input field after the cursor', () => {
+    const { handler, screen } = formHandler();
+    screen.cursorAddr = 3 * 80; // between the two fields, protected
+    handler.sendKey('Tab');
+    expect(screen.cursorAddr).toBe(QTY_START);
+  });
+
+  it('Home jumps to the first unprotected field', () => {
+    const { handler, screen } = formHandler();
+    screen.cursorAddr = QTY_START + 2;
+    handler.sendKey('Home');
+    expect(screen.cursorAddr).toBe(NAME_START);
+  });
+
+  it('arrows move freely (uppercase aliases accepted); Backspace shifts left within the field', () => {
+    const { handler, screen } = formHandler();
+    screen.cursorAddr = NAME_START;
+    handler.encoder.insertText('ABCD');
+    handler.sendKey('LEFT');
+    handler.sendKey('LEFT');
+    // cursor now after 'AB', on 'C'
+    handler.sendKey('Backspace'); // deletes 'B'
+    const value = screen.getFieldValue(screen.fields.find((f) => f.startAddr === NAME_START)!);
+    expect(value.trimEnd()).toBe('ACD');
+  });
+
+  it('Delete removes at cursor and NUL-fills the tail; MDT set', () => {
+    const { handler, screen } = formHandler();
+    screen.cursorAddr = NAME_START;
+    handler.encoder.insertText('WXYZ');
+    // Reset MDT via host write, then edit again — Delete alone must re-set it
+    handler.parser.parseRecord(Buffer.from([CMD.WRITE, WCC.RESET_MDT]));
+    screen.cursorAddr = NAME_START;
+    handler.sendKey('Delete'); // removes 'W'
+    const field = screen.fields.find((f) => f.startAddr === NAME_START)!;
+    expect(screen.getFieldValue(field).trimEnd()).toBe('XYZ');
+    expect(field.modified).toBe(true);
+    expect(screen.rawBuffer[NAME_START + 7]).toBe(0x00); // tail is NUL
+  });
+
+  it('EraseEOF clears cursor→field-end and sets MDT', () => {
+    const { handler, screen } = formHandler();
+    screen.cursorAddr = NAME_START;
+    handler.encoder.insertText('LONGNAME');
+    handler.parser.parseRecord(Buffer.from([CMD.WRITE, WCC.RESET_MDT]));
+    screen.cursorAddr = NAME_START + 4;
+    expect(handler.eraseEOF()).toBe(true);
+    const field = screen.fields.find((f) => f.startAddr === NAME_START)!;
+    expect(screen.getFieldValue(field).trimEnd()).toBe('LONG');
+    expect(field.modified).toBe(true);
+  });
+
+  it('Insert toggles insert mode; typing shifts right instead of overwriting', () => {
+    const { handler, screen } = formHandler();
+    screen.cursorAddr = NAME_START;
+    handler.encoder.insertText('ACD');
+    handler.sendKey('Insert');
+    expect(screen.insertMode).toBe(true);
+    screen.cursorAddr = NAME_START + 1;
+    handler.encoder.insertText('B');
+    const field = screen.fields.find((f) => f.startAddr === NAME_START)!;
+    expect(screen.getFieldValue(field).trimEnd()).toBe('ABCD');
+    handler.sendKey('Reset');
+    expect(screen.insertMode).toBe(false);
+  });
+
+  it('filling a field autoskips to the next unprotected field', () => {
+    const { handler, screen } = formHandler();
+    screen.cursorAddr = NAME_START;
+    handler.encoder.insertText('EXACTLY8'); // fills the 8-char field
+    expect(screen.cursorAddr).toBe(QTY_START);
+  });
+
+  it('FieldExit is not a 3270 key: not local, and rejected by sendKey', () => {
+    const { handler } = formHandler();
+    expect(handler.isLocalKey('FieldExit')).toBe(false);
+    expect(handler.isLocalKey('Tab')).toBe(true);
+    expect(handler.sendKey('FieldExit')).toBe(false);
+  });
+});
+
+describe('TN3270 readFieldValues (MDT read primitive)', () => {
+  it('returns only modified input fields by default, all input fields on request', () => {
+    const { handler, screen } = formHandler();
+    screen.cursorAddr = QTY_START;
+    handler.encoder.insertText('42');
+
+    const modified = handler.readFieldValues(true);
+    expect(modified).toHaveLength(1);
+    expect(modified[0]).toMatchObject({ row: 4, col: 5, length: 5, modified: true });
+    expect(modified[0].value.trimEnd()).toBe('42');
+
+    const all = handler.readFieldValues(false);
+    expect(all).toHaveLength(2);
+    expect(handler.traits.hasMdt).toBe(true);
+  });
+});

--- a/packages/proxy/src/tn3270/negotiation.test.ts
+++ b/packages/proxy/src/tn3270/negotiation.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect } from 'vitest';
+import { TN3270Handler } from '../protocols/tn3270-handler.js';
+import { FakeHost, expectBytes, sendBytes } from '../test-utils/fake-host.js';
+import { TELNET } from '../net/telnet.js';
+import { TN3270E, CMD, WCC } from './constants.js';
+
+const { IAC, SB, SE, DO, WILL, WONT, EOR } = TELNET;
+const E = TELNET.OPT_TN3270E;
+
+function ascii(text: string): number[] {
+  return [...text].map((c) => c.charCodeAt(0));
+}
+
+describe('TN3270 negotiation over a real socket', () => {
+  it('classic RFC 1576: TTYPE + EOR + BINARY when the server has no TN3270E', async () => {
+    const host = await FakeHost.start([
+      sendBytes([IAC, DO, TELNET.OPT_TTYPE]),
+      expectBytes([IAC, WILL, TELNET.OPT_TTYPE], 'WILL TTYPE'),
+      sendBytes([IAC, SB, TELNET.OPT_TTYPE, TELNET.TTYPE_SEND, IAC, SE]),
+      expectBytes(
+        [IAC, SB, TELNET.OPT_TTYPE, TELNET.TTYPE_IS, ...ascii('IBM-3278-2'), IAC, SE],
+        'TTYPE IS IBM-3278-2',
+      ),
+      sendBytes([IAC, DO, TELNET.OPT_EOR, IAC, DO, TELNET.OPT_BINARY]),
+      expectBytes([IAC, WILL, TELNET.OPT_EOR, IAC, WILL, TELNET.OPT_BINARY], 'WILL EOR+BINARY'),
+      // Paint a minimal screen so we can assert data flows unheadered
+      sendBytes([CMD.ERASE_WRITE, WCC.KEYBOARD_RESTORE, 0xc8, 0xc9, IAC, EOR]), // 'HI'
+    ]);
+
+    const handler = new TN3270Handler();
+    const screenChanged = new Promise<void>((resolve) =>
+      handler.once('screenChange', () => resolve()),
+    );
+    await handler.connect('127.0.0.1', host.port, { tn3270e: false });
+    await host.finished;
+    await screenChanged;
+    expect(handler.getScreenData().content).toContain('HI');
+    expect(handler.connection.isTn3270e).toBe(false);
+    handler.destroy();
+    await host.stop();
+  });
+
+  it('refuses TN3270E with WONT when tn3270e:false', async () => {
+    const host = await FakeHost.start([
+      sendBytes([IAC, DO, E]),
+      expectBytes([IAC, WONT, E], 'WONT TN3270E'),
+    ]);
+    const handler = new TN3270Handler();
+    await handler.connect('127.0.0.1', host.port, { tn3270e: false });
+    await host.finished;
+    handler.destroy();
+    await host.stop();
+  });
+
+  it('full RFC 2355: device-type REQUEST/IS, empty FUNCTIONS, 5-byte headers both ways', async () => {
+    const host = await FakeHost.start([
+      // Option negotiation
+      sendBytes([IAC, DO, E]),
+      expectBytes([IAC, WILL, E], 'WILL TN3270E'),
+      // DEVICE-TYPE handshake — we request the -E variant
+      sendBytes([IAC, SB, E, TN3270E.SEND, TN3270E.DEVICE_TYPE, IAC, SE]),
+      expectBytes(
+        [IAC, SB, E, TN3270E.DEVICE_TYPE, TN3270E.REQUEST, ...ascii('IBM-3278-2-E'), IAC, SE],
+        'DEVICE-TYPE REQUEST',
+      ),
+      sendBytes([
+        IAC, SB, E, TN3270E.DEVICE_TYPE, TN3270E.IS,
+        ...ascii('IBM-3278-2-E'), TN3270E.CONNECT, ...ascii('TCP00001'),
+        IAC, SE,
+      ]),
+      // FUNCTIONS — we propose the empty set, server agrees with IS
+      expectBytes([IAC, SB, E, TN3270E.FUNCTIONS, TN3270E.REQUEST, IAC, SE], 'FUNCTIONS REQUEST []'),
+      sendBytes([IAC, SB, E, TN3270E.FUNCTIONS, TN3270E.IS, IAC, SE]),
+      // Headered 3270-DATA record: Erase/Write + restore + 'HI'
+      sendBytes([
+        TN3270E.DT_3270_DATA, 0x00, 0x00, 0x00, 0x00,
+        CMD.ERASE_WRITE, WCC.KEYBOARD_RESTORE, 0xc8, 0xc9,
+        IAC, EOR,
+      ]),
+      // Client reply to Enter must carry the outbound 5-byte header
+      expectBytes([TN3270E.DT_3270_DATA, 0x00, 0x00, 0x00, 0x00, 0x7d], 'headered AID'),
+    ]);
+
+    const handler = new TN3270Handler();
+    const screenChanged = new Promise<void>((resolve) =>
+      handler.once('screenChange', () => resolve()),
+    );
+    await handler.connect('127.0.0.1', host.port);
+    await screenChanged;
+    expect(handler.connection.isTn3270e).toBe(true);
+    expect(handler.connection.assignedLuName).toBe('TCP00001');
+    expect(handler.getScreenData().content).toContain('HI');
+    expect(handler.getScreenData().keyboard_locked).toBe(false);
+
+    handler.sendKey('Enter');
+    await host.finished;
+    handler.destroy();
+    await host.stop();
+  });
+
+  it('retries without -E when the host rejects the extended device type', async () => {
+    const host = await FakeHost.start([
+      sendBytes([IAC, DO, E]),
+      expectBytes([IAC, WILL, E]),
+      sendBytes([IAC, SB, E, TN3270E.SEND, TN3270E.DEVICE_TYPE, IAC, SE]),
+      expectBytes([IAC, SB, E, TN3270E.DEVICE_TYPE, TN3270E.REQUEST, ...ascii('IBM-3278-2-E'), IAC, SE]),
+      sendBytes([IAC, SB, E, TN3270E.DEVICE_TYPE, TN3270E.REJECT, TN3270E.REASON, 0x00, IAC, SE]),
+      expectBytes(
+        [IAC, SB, E, TN3270E.DEVICE_TYPE, TN3270E.REQUEST, ...ascii('IBM-3278-2'), IAC, SE],
+        'retry without -E',
+      ),
+    ]);
+    const handler = new TN3270Handler();
+    await handler.connect('127.0.0.1', host.port);
+    await host.finished;
+    handler.destroy();
+    await host.stop();
+  });
+
+  it('SSCP-LU data (VTAM USS screens) renders through the command-less fallback', async () => {
+    const host = await FakeHost.start([
+      sendBytes([IAC, DO, E]),
+      expectBytes([IAC, WILL, E]),
+      sendBytes([IAC, SB, E, TN3270E.SEND, TN3270E.DEVICE_TYPE, IAC, SE]),
+      expectBytes([IAC, SB, E, TN3270E.DEVICE_TYPE, TN3270E.REQUEST, ...ascii('IBM-3278-2-E'), IAC, SE]),
+      sendBytes([IAC, SB, E, TN3270E.DEVICE_TYPE, TN3270E.IS, ...ascii('IBM-3278-2-E'), IAC, SE]),
+      expectBytes([IAC, SB, E, TN3270E.FUNCTIONS, TN3270E.REQUEST, IAC, SE]),
+      sendBytes([IAC, SB, E, TN3270E.FUNCTIONS, TN3270E.IS, IAC, SE]),
+      // SSCP-LU data record: raw EBCDIC text, no 3270 command byte
+      sendBytes([TN3270E.DT_SSCP_LU_DATA, 0x00, 0x00, 0x00, 0x00, 0xd3, 0xd6, 0xc7, 0xd6, 0xd5, IAC, EOR]), // LOGON
+    ]);
+    const handler = new TN3270Handler();
+    const screenChanged = new Promise<void>((resolve) =>
+      handler.once('screenChange', () => resolve()),
+    );
+    await handler.connect('127.0.0.1', host.port);
+    await screenChanged;
+    expect(handler.getScreenData().content).toContain('LOGON');
+    handler.destroy();
+    await host.stop();
+  });
+});
+
+describe('alternate screen sizes', () => {
+  it('EWA switches a Model 4 to 43x80 and EW back to 24x80', async () => {
+    const host = await FakeHost.start([
+      sendBytes([CMD.ERASE_WRITE_ALTERNATE, WCC.KEYBOARD_RESTORE, 0xc8, IAC, EOR]),
+    ]);
+    const handler = new TN3270Handler();
+    const screenChanged = new Promise<void>((resolve) =>
+      handler.once('screenChange', () => resolve()),
+    );
+    await handler.connect('127.0.0.1', host.port, {
+      terminalType: 'IBM-3278-4',
+      tn3270e: false,
+    });
+    await screenChanged;
+    expect(handler.getScreenData().rows).toBe(43);
+    expect(handler.getScreenData().cols).toBe(80);
+
+    // A plain Erase/Write drops back to the 24x80 default size
+    handler.parser.parseRecord(Buffer.from([CMD.ERASE_WRITE, WCC.KEYBOARD_RESTORE]));
+    expect(handler.screen.rows).toBe(24);
+    handler.destroy();
+    await host.stop();
+  });
+});

--- a/packages/proxy/src/tn3270/parser.test.ts
+++ b/packages/proxy/src/tn3270/parser.test.ts
@@ -260,11 +260,10 @@ describe('TN3270Encoder', () => {
   it('short-read AIDs (PA1/PA2/PA3/Clear) transmit the AID byte only', () => {
     const { encoder } = setup();
     for (const key of ['PA1', 'PA2', 'PA3', 'Clear']) {
-      const wire = encoder.buildAidResponse(key)!;
-      // AID byte + IAC EOR framing and nothing else
-      expect(wire.length, key).toBe(3);
-      expect(wire[1]).toBe(0xff);
-      expect(wire[2]).toBe(0xef);
+      const record = encoder.buildAidResponse(key)!;
+      // the raw record is the AID byte and nothing else (framing is the
+      // connection's job)
+      expect(record.length, key).toBe(1);
     }
   });
 

--- a/packages/proxy/src/tn3270/parser.test.ts
+++ b/packages/proxy/src/tn3270/parser.test.ts
@@ -1,0 +1,285 @@
+import { describe, it, expect } from 'vitest';
+import { ScreenBuffer3270 } from './screen.js';
+import { TN3270Parser } from './parser.js';
+import { TN3270Encoder } from './encoder.js';
+import { CMD, ORDER, FA, WCC, EXT_ATTR, HIGHLIGHT, COLOR, encodeAddress } from './constants.js';
+import { charToEbcdic } from '../encoding/ebcdic.js';
+import { computeStructuralSignature } from '../structural-signature.js';
+
+function eb(text: string): number[] {
+  return [...text].map((c) => charToEbcdic(c));
+}
+
+function addr(screen: ScreenBuffer3270, row: number, col: number): number[] {
+  return [...encodeAddress(row * screen.cols + col, screen.size)];
+}
+
+function setup() {
+  const screen = new ScreenBuffer3270();
+  const parser = new TN3270Parser(screen);
+  const encoder = new TN3270Encoder(screen);
+  return { screen, parser, encoder };
+}
+
+/** Erase/Write with an unprotected field at (r,c) of the given length. */
+function writeWithField(
+  screen: ScreenBuffer3270,
+  parser: TN3270Parser,
+  row: number,
+  col: number,
+  label: string,
+  wcc = WCC.KEYBOARD_RESTORE,
+) {
+  const attrAddr = row * screen.cols + col - 1;
+  parser.parseRecord(
+    Buffer.from([
+      CMD.ERASE_WRITE,
+      wcc,
+      ORDER.SBA, ...[...encodeAddress(attrAddr - label.length, screen.size)],
+      ...eb(label),
+      ORDER.SF, 0x40, // unprotected/normal attr (graphic-converted) before (row,col)
+    ]),
+  );
+}
+
+describe('TN3270Parser — WCC semantics (GA23-0059 bit layout)', () => {
+  it('keyboard restore (0x02) unlocks; alarm (0x04) is one-shot on ScreenData', () => {
+    const { screen, parser } = setup();
+    screen.keyboardLocked = true;
+    parser.parseRecord(Buffer.from([CMD.WRITE, WCC.KEYBOARD_RESTORE | WCC.SOUND_ALARM]));
+    expect(screen.keyboardLocked).toBe(false);
+    const first = screen.toScreenData();
+    expect(first.keyboard_locked).toBe(false);
+    expect(first.alarm).toBe(true);
+    expect(screen.toScreenData().alarm).toBeUndefined(); // consumed
+  });
+
+  it('a write WITHOUT keyboard restore leaves the keyboard locked', () => {
+    const { screen, parser } = setup();
+    screen.keyboardLocked = true;
+    parser.parseRecord(Buffer.from([CMD.WRITE, 0x00, ...eb('X')]));
+    expect(screen.keyboardLocked).toBe(true);
+  });
+
+  it('reset MDT (0x01) clears field.modified and the attribute MDT bit', () => {
+    const { screen, parser, encoder } = setup();
+    writeWithField(screen, parser, 2, 10, 'NAME:');
+    screen.cursorAddr = 2 * screen.cols + 10;
+    encoder.insertText('AB');
+    expect(screen.fields.find((f) => f.modified)).toBeTruthy();
+    parser.parseRecord(Buffer.from([CMD.WRITE, WCC.RESET_MDT]));
+    expect(screen.fields.some((f) => f.modified)).toBe(false);
+    expect(screen.attrBuffer.filter((a) => a & FA.MDT)).toHaveLength(0);
+  });
+
+  it('Erase All Unprotected clears unprotected data to NULs and restores the keyboard', () => {
+    const { screen, parser, encoder } = setup();
+    writeWithField(screen, parser, 2, 10, 'NAME:');
+    screen.cursorAddr = 2 * screen.cols + 10;
+    encoder.insertText('AB');
+    screen.keyboardLocked = true;
+    parser.parseRecord(Buffer.from([CMD.ERASE_ALL_UNPROTECTED]));
+    expect(screen.keyboardLocked).toBe(false);
+    expect(screen.getCharAt(2 * screen.cols + 10)).toBe(' ');
+    expect(screen.rawBuffer[2 * screen.cols + 10]).toBe(0x00);
+    expect(screen.getFieldValue(screen.fields[0]).trim()).toBe('');
+  });
+});
+
+describe('TN3270Parser — orders', () => {
+  it('SBA + data lands text at the addressed position (golden row)', () => {
+    const { screen, parser } = setup();
+    parser.parseRecord(
+      Buffer.from([CMD.ERASE_WRITE, 0x00, ORDER.SBA, ...addr(screen, 1, 5), ...eb('HELLO')]),
+    );
+    const data = screen.toScreenData();
+    expect(data.content.split('\n')[1].slice(5, 10)).toBe('HELLO');
+    expect(screen.rawBuffer[screen.cols + 5]).toBe(charToEbcdic('H'));
+  });
+
+  it('SFE surfaces color and highlight onto the wire field', () => {
+    const { screen, parser } = setup();
+    parser.parseRecord(
+      Buffer.from([
+        CMD.ERASE_WRITE, 0x00,
+        ORDER.SBA, ...addr(screen, 3, 0),
+        ORDER.SFE, 0x03,
+        0xC0, 0x40, // basic attr: unprotected/normal
+        EXT_ATTR.COLOR, COLOR.RED,
+        EXT_ATTR.HIGHLIGHT, HIGHLIGHT.REVERSE,
+        ...eb('VAL'),
+        ORDER.SF, 0x40 | FA.PROTECTED, // terminate the field
+      ]),
+    );
+    const field = screen.toScreenData().fields[0];
+    expect(field.color).toBe('red');
+    expect(field.is_reverse).toBe(true);
+    expect(field.is_input).toBe(true);
+  });
+
+  it('SA starts a character-attribute run and SA ALL(0x00) ends it', () => {
+    const { screen, parser } = setup();
+    parser.parseRecord(
+      Buffer.from([
+        CMD.ERASE_WRITE, 0x00,
+        ORDER.SBA, ...addr(screen, 0, 0),
+        ORDER.SA, EXT_ATTR.COLOR, COLOR.YELLOW,
+        ...eb('AB'),
+        ORDER.SA, EXT_ATTR.ALL, 0x00,
+        ...eb('C'),
+      ]),
+    );
+    expect(screen.colorBuffer[0]).toBe(COLOR.YELLOW);
+    expect(screen.colorBuffer[1]).toBe(COLOR.YELLOW);
+    expect(screen.colorBuffer[2]).toBe(0);
+  });
+
+  it('MF modifies the attribute at the current address and advances past it', () => {
+    const { screen, parser } = setup();
+    // Field attribute at (0,4), then MF it to protected+MDT-less attr 0x20
+    parser.parseRecord(
+      Buffer.from([
+        CMD.ERASE_WRITE, 0x00,
+        ORDER.SBA, ...addr(screen, 0, 4),
+        ORDER.SF, 0x40,
+        ORDER.SBA, ...addr(screen, 0, 4),
+        ORDER.MF, 0x01, 0xC0, 0x40 | FA.PROTECTED,
+        ...eb('Z'), // must land AFTER the attribute (addr advanced)
+      ]),
+    );
+    expect(screen.attrBuffer[4]).toBe(0x40 | FA.PROTECTED);
+    expect(screen.getCharAt(5)).toBe('Z');
+  });
+
+  it('MF at a non-attribute position consumes its pairs and does not advance', () => {
+    const { screen, parser } = setup();
+    parser.parseRecord(
+      Buffer.from([
+        CMD.ERASE_WRITE, 0x00,
+        ORDER.SBA, ...addr(screen, 0, 0),
+        ORDER.MF, 0x01, 0xC0, 0x40 | FA.PROTECTED,
+        ...eb('Q'),
+      ]),
+    );
+    expect(screen.attrBuffer[0]).toBe(0);
+    expect(screen.getCharAt(0)).toBe('Q'); // wrote at 0, not 1
+  });
+
+  it('RA repeats to target, wraps, and stop==current fills the whole buffer', () => {
+    const { screen, parser } = setup();
+    parser.parseRecord(
+      Buffer.from([
+        CMD.ERASE_WRITE, 0x00,
+        ORDER.SBA, ...addr(screen, 0, 0),
+        ORDER.RA, ...addr(screen, 0, 0), charToEbcdic('*'),
+      ]),
+    );
+    expect(screen.buffer.every((c) => c === '*')).toBe(true);
+  });
+
+  it('RA with NUL fill produces blank cells that stay NUL in the raw buffer', () => {
+    const { screen, parser } = setup();
+    parser.parseRecord(
+      Buffer.from([
+        CMD.ERASE_WRITE, 0x00,
+        ORDER.SBA, ...addr(screen, 0, 0),
+        ...eb('AB'),
+        ORDER.SBA, ...addr(screen, 0, 0),
+        ORDER.RA, ...addr(screen, 0, 2), 0x00,
+      ]),
+    );
+    expect(screen.getCharAt(0)).toBe(' ');
+    expect(screen.rawBuffer[0]).toBe(0x00);
+    expect(screen.rawBuffer[2]).toBe(0x00); // untouched (still from erase)
+  });
+
+  it('EUA erases only unprotected content up to the target', () => {
+    const { screen, parser } = setup();
+    // protected label + unprotected field with content
+    parser.parseRecord(
+      Buffer.from([
+        CMD.ERASE_WRITE, 0x00,
+        ORDER.SBA, ...addr(screen, 0, 0),
+        ORDER.SF, 0x40 | FA.PROTECTED, ...eb('LBL'),
+        ORDER.SF, 0x40, ...eb('DATA'),
+        ORDER.SBA, ...addr(screen, 0, 0),
+        ORDER.EUA, ...addr(screen, 1, 0),
+      ]),
+    );
+    const row0 = screen.toScreenData().content.split('\n')[0];
+    expect(row0).toContain('LBL'); // protected survives
+    expect(row0).not.toContain('DATA'); // unprotected erased
+  });
+});
+
+describe('TN3270 ScreenData surface', () => {
+  it('emits structural_signature computed from input-field geometry', () => {
+    const { screen, parser } = setup();
+    writeWithField(screen, parser, 4, 20, 'USERID');
+    const data = screen.toScreenData();
+    expect(data.structural_signature).toBeDefined();
+    expect(data.structural_signature).toBe(computeStructuralSignature(data.fields));
+  });
+
+  it('flags numeric fields with is_numeric and typed fields with modified', () => {
+    const { screen, parser, encoder } = setup();
+    parser.parseRecord(
+      Buffer.from([
+        CMD.ERASE_WRITE, WCC.KEYBOARD_RESTORE,
+        ORDER.SBA, ...addr(screen, 2, 0),
+        ORDER.SF, 0x40 | FA.NUMERIC, // unprotected numeric
+        ...eb('42'),
+        ORDER.SF, 0x40 | FA.PROTECTED,
+      ]),
+    );
+    screen.cursorAddr = 2 * screen.cols + 1;
+    encoder.insertText('7');
+    const fields = screen.toScreenData().fields;
+    const numeric = fields.find((f) => f.is_numeric);
+    expect(numeric).toBeDefined();
+    expect(numeric!.modified).toBe(true);
+  });
+
+  it('host read commands set pendingRead instead of being dropped', () => {
+    const { parser } = setup();
+    parser.parseRecord(Buffer.from([CMD.READ_BUFFER]));
+    expect(parser.pendingRead).toBe('buffer');
+    parser.parseRecord(Buffer.from([CMD.READ_MODIFIED]));
+    expect(parser.pendingRead).toBe('modified');
+  });
+
+  it('WSF Read Partition Query sets pendingQueryReply', () => {
+    const { parser } = setup();
+    // WSF + one SF: len=5, id=0x01 (Read Partition), pid=0xFF, type=0x02 (Query)
+    parser.parseRecord(Buffer.from([CMD.WRITE_STRUCTURED_FIELD, 0x00, 0x05, 0x01, 0xff, 0x02]));
+    expect(parser.pendingQueryReply).toBe(true);
+  });
+});
+
+describe('TN3270Encoder', () => {
+  it('short-read AIDs (PA1/PA2/PA3/Clear) transmit the AID byte only', () => {
+    const { encoder } = setup();
+    for (const key of ['PA1', 'PA2', 'PA3', 'Clear']) {
+      const wire = encoder.buildAidResponse(key)!;
+      // AID byte + IAC EOR framing and nothing else
+      expect(wire.length, key).toBe(3);
+      expect(wire[1]).toBe(0xff);
+      expect(wire[2]).toBe(0xef);
+    }
+  });
+
+  it('Enter transmits AID + cursor + SBA-addressed modified fields', () => {
+    const { screen, parser, encoder } = setup();
+    writeWithField(screen, parser, 2, 10, 'NAME:');
+    screen.cursorAddr = 2 * screen.cols + 10;
+    encoder.insertText('AB');
+    const wire = encoder.buildAidResponse('Enter')!;
+    expect(wire[0]).toBe(0x7d); // ENTER AID
+    expect(wire.length).toBeGreaterThan(3);
+    const sbaIdx = wire.indexOf(ORDER.SBA);
+    expect(sbaIdx).toBeGreaterThan(0);
+    // Field data follows the 2-byte address: 'AB' in EBCDIC
+    expect(wire[sbaIdx + 3]).toBe(charToEbcdic('A'));
+    expect(wire[sbaIdx + 4]).toBe(charToEbcdic('B'));
+  });
+});

--- a/packages/proxy/src/tn3270/parser.ts
+++ b/packages/proxy/src/tn3270/parser.ts
@@ -54,8 +54,14 @@ export class TN3270Parser {
 
       case CMD.ERASE_WRITE:
       case SNA_CMD.ERASE_WRITE:
+        this.screen.useAlternate(false);
+        this.screen.clear();
+        modified = this.parseWrite(record, 1, false);
+        break;
+
       case CMD.ERASE_WRITE_ALTERNATE:
       case SNA_CMD.ERASE_WRITE_ALTERNATE:
+        this.screen.useAlternate(true);
         this.screen.clear();
         modified = this.parseWrite(record, 1, false);
         break;
@@ -255,7 +261,7 @@ export class TN3270Parser {
     if (charByte === ORDER.GE && pos < data.length) {
       charByte = data[pos++]; // graphic escape — next byte is the char
     }
-    const repeatChar = charByte === 0x00 ? ' ' : ebcdicToChar(charByte);
+    const repeatChar = charByte === 0x00 ? ' ' : ebcdicToChar(charByte, this.screen.codePage);
 
     const target = targetAddr % this.screen.size;
     let addr = this.screen.currentAddr;
@@ -310,7 +316,7 @@ export class TN3270Parser {
     pos++;
     if (pos < data.length) {
       const geByte = data[pos++];
-      this.writeData(this.screen.currentAddr, ebcdicToChar(geByte), geByte);
+      this.writeData(this.screen.currentAddr, ebcdicToChar(geByte, this.screen.codePage), geByte);
       this.screen.currentAddr = (this.screen.currentAddr + 1) % this.screen.size;
       this.writeModified = true;
     }
@@ -320,7 +326,7 @@ export class TN3270Parser {
   /** Regular EBCDIC data byte (0x00 = NUL position: blank but not space). */
   private dataByte(data: Buffer, pos: number): number {
     const byte = data[pos];
-    const ch = byte === 0x00 ? ' ' : ebcdicToChar(byte);
+    const ch = byte === 0x00 ? ' ' : ebcdicToChar(byte, this.screen.codePage);
     this.writeData(this.screen.currentAddr, ch, byte);
     this.screen.currentAddr = (this.screen.currentAddr + 1) % this.screen.size;
     this.writeModified = true;

--- a/packages/proxy/src/tn3270/parser.ts
+++ b/packages/proxy/src/tn3270/parser.ts
@@ -1,12 +1,36 @@
 import { ScreenBuffer3270 } from './screen.js';
-import { CMD, SNA_CMD, ORDER, FA, EXT_ATTR, decodeAddress } from './constants.js';
+import { CMD, SNA_CMD, ORDER, FA, EXT_ATTR, WCC, decodeAddress } from './constants.js';
 import { ebcdicToChar } from '../encoding/ebcdic.js';
+
+/** Which reply a host-initiated read command is waiting for. */
+export type PendingRead = 'buffer' | 'modified' | 'modifiedAll' | null;
+
+/** Order handlers return the next parse position, or STOP on truncation. */
+const STOP = -1;
 
 /**
  * Parses 3270 data stream records and updates the screen buffer.
  */
 export class TN3270Parser {
-  private screen: ScreenBuffer3270;
+  private readonly screen: ScreenBuffer3270;
+
+  /**
+   * Host-initiated read pending a reply. The parser never writes to the
+   * socket itself — the handler checks this after parseRecord() and flushes
+   * the matching encoder reply (same pattern as the 5250 pendingQueryReply).
+   */
+  pendingRead: PendingRead = null;
+  /** Host sent WSF Read Partition (Query) — handler must send a Query Reply. */
+  pendingQueryReply: boolean = false;
+
+  /**
+   * Character attributes set by SA orders — apply to every subsequent data
+   * byte written until changed or reset (SA 0x00) / next Write command.
+   */
+  private saHighlight = 0;
+  private saColor = 0;
+  /** Whether the current Write mutated the screen (set by order handlers). */
+  private writeModified = false;
 
   constructor(screen: ScreenBuffer3270) {
     this.screen = screen;
@@ -30,10 +54,6 @@ export class TN3270Parser {
 
       case CMD.ERASE_WRITE:
       case SNA_CMD.ERASE_WRITE:
-        this.screen.clear();
-        modified = this.parseWrite(record, 1, false);
-        break;
-
       case CMD.ERASE_WRITE_ALTERNATE:
       case SNA_CMD.ERASE_WRITE_ALTERNATE:
         this.screen.clear();
@@ -42,24 +62,31 @@ export class TN3270Parser {
 
       case CMD.ERASE_ALL_UNPROTECTED:
       case SNA_CMD.ERASE_ALL_UNPROTECTED:
+        // Per GA23-0059: EAU clears unprotected positions to NULs, resets
+        // their MDTs, restores the keyboard, and resets the AID.
         this.screen.clearUnprotected();
+        this.screen.keyboardLocked = false;
         modified = true;
         break;
 
       case CMD.WRITE_STRUCTURED_FIELD:
       case SNA_CMD.WRITE_STRUCTURED_FIELD:
-        // Structured fields — parse each SF
         modified = this.parseStructuredFields(record, 1);
         break;
 
       case CMD.READ_BUFFER:
-      case CMD.READ_MODIFIED:
-      case CMD.READ_MODIFIED_ALL:
       case SNA_CMD.READ_BUFFER:
+        this.pendingRead = 'buffer';
+        break;
+
+      case CMD.READ_MODIFIED:
       case SNA_CMD.READ_MODIFIED:
+        this.pendingRead = 'modified';
+        break;
+
+      case CMD.READ_MODIFIED_ALL:
       case SNA_CMD.READ_MODIFIED_ALL:
-        // Read commands — don't modify screen, but may need to trigger a response
-        // Handled at the handler level
+        this.pendingRead = 'modifiedAll';
         break;
 
       default:
@@ -84,196 +111,249 @@ export class TN3270Parser {
   private parseWrite(data: Buffer, offset: number, skipWCC: boolean): boolean {
     let pos = offset;
 
-    // Parse WCC (Write Control Character)
+    // A new Write ends any character-attribute run from a previous record.
+    this.saHighlight = 0;
+    this.saColor = 0;
+    this.writeModified = false;
+
     if (!skipWCC && pos < data.length) {
-      const wcc = data[pos++];
-      // WCC bit 0: reset MDT flags
-      if (wcc & 0x01) {
-        for (const field of this.screen.fields) {
-          field.modified = false;
-          // Clear MDT bit in attribute buffer too
-          const attr = this.screen.attrBuffer[field.attrAddr];
-          if (attr !== 0) {
-            this.screen.attrBuffer[field.attrAddr] = attr & ~FA.MDT;
-          }
+      this.applyWCC(data[pos++]);
+    }
+
+    while (pos >= 0 && pos < data.length) {
+      pos = this.applyOrder(data, pos);
+    }
+
+    return this.writeModified;
+  }
+
+  /** Dispatch one order (or data byte) at `pos`; returns next pos or STOP. */
+  private applyOrder(data: Buffer, pos: number): number {
+    switch (data[pos]) {
+      case ORDER.SBA: return this.orderSBA(data, pos);
+      case ORDER.SF:  return this.orderSF(data, pos);
+      case ORDER.SFE: return this.orderSFE(data, pos);
+      case ORDER.SA:  return this.orderSA(data, pos);
+      case ORDER.MF:  return this.orderMF(data, pos);
+      case ORDER.IC:
+        this.screen.cursorAddr = this.screen.currentAddr;
+        return pos + 1;
+      case ORDER.PT:
+        this.advanceToNextUnprotected();
+        return pos + 1;
+      case ORDER.RA:  return this.orderRA(data, pos);
+      case ORDER.EUA: return this.orderEUA(data, pos);
+      case ORDER.GE:  return this.orderGE(data, pos);
+      default:        return this.dataByte(data, pos);
+    }
+  }
+
+  /** Set Buffer Address: 2 address bytes follow. */
+  private orderSBA(data: Buffer, pos: number): number {
+    if (pos + 2 >= data.length) return STOP;
+    const addr = decodeAddress(data[pos + 1], data[pos + 2]);
+    this.screen.currentAddr = addr % this.screen.size;
+    return pos + 3;
+  }
+
+  /** Start Field: 1 attribute byte follows. */
+  private orderSF(data: Buffer, pos: number): number {
+    if (pos + 1 >= data.length) return STOP;
+    this.screen.setFieldAttribute(this.screen.currentAddr, data[pos + 1]);
+    this.screen.currentAddr = (this.screen.currentAddr + 1) % this.screen.size;
+    this.writeModified = true;
+    return pos + 2;
+  }
+
+  /** Start Field Extended: pair count, then (type, value) pairs. */
+  private orderSFE(data: Buffer, pos: number): number {
+    if (pos + 1 >= data.length) return STOP;
+    pos++;
+    const pairCount = data[pos++];
+    let fieldAttr = 0;
+    let extHighlight = 0;
+    let extColor = 0;
+
+    for (let i = 0; i < pairCount && pos + 1 < data.length; i++) {
+      const attrType = data[pos++];
+      const attrValue = data[pos++];
+      if (attrType === 0xC0) {
+        fieldAttr = attrValue; // basic field attribute
+      } else if (attrType === EXT_ATTR.HIGHLIGHT) {
+        extHighlight = attrValue;
+      } else if (attrType === EXT_ATTR.COLOR) {
+        extColor = attrValue;
+      }
+      // Other extended attributes (charset, validation, outlining) are
+      // tolerated and skipped.
+    }
+
+    this.screen.setFieldAttribute(this.screen.currentAddr, fieldAttr || FA.PROTECTED);
+    this.screen.highlightBuffer[this.screen.currentAddr] = extHighlight;
+    this.screen.colorBuffer[this.screen.currentAddr] = extColor;
+    this.screen.currentAddr = (this.screen.currentAddr + 1) % this.screen.size;
+    this.writeModified = true;
+    return pos;
+  }
+
+  /**
+   * Set Attribute: starts a character-attribute run — applies to every
+   * subsequent data byte until changed or reset (type 0x00 = ALL).
+   */
+  private orderSA(data: Buffer, pos: number): number {
+    if (pos + 2 >= data.length) return STOP;
+    const saType = data[pos + 1];
+    const saValue = data[pos + 2];
+    if (saType === EXT_ATTR.ALL) {
+      this.saHighlight = 0;
+      this.saColor = 0;
+    } else if (saType === EXT_ATTR.HIGHLIGHT) {
+      this.saHighlight = saValue;
+    } else if (saType === EXT_ATTR.COLOR) {
+      this.saColor = saValue;
+    }
+    return pos + 3;
+  }
+
+  /**
+   * Modify Field: applies (type, value) pairs to the field attribute AT the
+   * current address, then advances past it. If the current address holds no
+   * field attribute the order is skipped (the spec treats it as a rejected
+   * op; we consume its pairs and continue).
+   */
+  private orderMF(data: Buffer, pos: number): number {
+    if (pos + 1 >= data.length) return STOP;
+    pos++;
+    const pairCount = data[pos++];
+    const cur = this.screen.currentAddr;
+    const atAttr = this.screen.attrBuffer[cur] !== 0;
+    for (let i = 0; i < pairCount && pos + 1 < data.length; i++) {
+      const mfType = data[pos++];
+      const mfValue = data[pos++];
+      if (!atAttr) continue;
+      if (mfType === 0xC0) {
+        this.screen.attrBuffer[cur] = mfValue;
+      } else if (mfType === EXT_ATTR.HIGHLIGHT) {
+        this.screen.highlightBuffer[cur] = mfValue;
+      } else if (mfType === EXT_ATTR.COLOR) {
+        this.screen.colorBuffer[cur] = mfValue;
+      }
+    }
+    if (atAttr) {
+      this.screen.currentAddr = (cur + 1) % this.screen.size;
+      this.writeModified = true;
+    }
+    return pos;
+  }
+
+  /** Repeat to Address: 2 address bytes + 1 char byte (optionally GE'd). */
+  private orderRA(data: Buffer, pos: number): number {
+    if (pos + 3 >= data.length) return STOP;
+    const targetAddr = decodeAddress(data[pos + 1], data[pos + 2]);
+    let charByte = data[pos + 3];
+    pos += 4;
+    if (charByte === ORDER.GE && pos < data.length) {
+      charByte = data[pos++]; // graphic escape — next byte is the char
+    }
+    const repeatChar = charByte === 0x00 ? ' ' : ebcdicToChar(charByte);
+
+    const target = targetAddr % this.screen.size;
+    let addr = this.screen.currentAddr;
+    // Per spec: stop address == current address fills the ENTIRE buffer.
+    do {
+      this.writeData(addr, repeatChar, charByte);
+      addr = (addr + 1) % this.screen.size;
+    } while (addr !== target);
+    this.screen.currentAddr = target;
+    this.writeModified = true;
+    return pos;
+  }
+
+  /**
+   * Erase Unprotected to Address: 2 address bytes. Protection is judged
+   * from the LIVE attribute buffer — the fields list is only rebuilt after
+   * the record, so it is stale for orders inside the same Write.
+   */
+  private orderEUA(data: Buffer, pos: number): number {
+    if (pos + 2 >= data.length) return STOP;
+    const euaEnd = decodeAddress(data[pos + 1], data[pos + 2]) % this.screen.size;
+    let governing = this.governingAttr(this.screen.currentAddr);
+    let euaAddr = this.screen.currentAddr;
+    while (euaAddr !== euaEnd) {
+      const posAttr = this.screen.attrBuffer[euaAddr];
+      if (posAttr !== 0) {
+        governing = posAttr; // attribute byte itself is never erased
+      } else if ((governing & FA.PROTECTED) === 0) {
+        // unprotected — or unformatted screen (governing 0), which the
+        // spec also erases
+        this.screen.setCharAt(euaAddr, ' ', 0x00);
+      }
+      euaAddr = (euaAddr + 1) % this.screen.size;
+    }
+    this.screen.currentAddr = euaEnd;
+    this.writeModified = true;
+    return pos + 3;
+  }
+
+  /** Attribute governing `addr`: nearest field attribute at/behind it (0 = unformatted). */
+  private governingAttr(addr: number): number {
+    const size = this.screen.size;
+    for (let back = 1; back <= size; back++) {
+      const a = (addr - back + size) % size;
+      if (this.screen.attrBuffer[a] !== 0) return this.screen.attrBuffer[a];
+    }
+    return 0;
+  }
+
+  /** Graphic Escape: next byte is a graphic character. */
+  private orderGE(data: Buffer, pos: number): number {
+    pos++;
+    if (pos < data.length) {
+      const geByte = data[pos++];
+      this.writeData(this.screen.currentAddr, ebcdicToChar(geByte), geByte);
+      this.screen.currentAddr = (this.screen.currentAddr + 1) % this.screen.size;
+      this.writeModified = true;
+    }
+    return pos;
+  }
+
+  /** Regular EBCDIC data byte (0x00 = NUL position: blank but not space). */
+  private dataByte(data: Buffer, pos: number): number {
+    const byte = data[pos];
+    const ch = byte === 0x00 ? ' ' : ebcdicToChar(byte);
+    this.writeData(this.screen.currentAddr, ch, byte);
+    this.screen.currentAddr = (this.screen.currentAddr + 1) % this.screen.size;
+    this.writeModified = true;
+    return pos + 1;
+  }
+
+  /** Apply Write Control Character bits (GA23-0059 layout). */
+  private applyWCC(wcc: number): void {
+    if (wcc & WCC.RESET_MDT) {
+      for (const field of this.screen.fields) {
+        field.modified = false;
+        const attr = this.screen.attrBuffer[field.attrAddr];
+        if (attr !== 0) {
+          this.screen.attrBuffer[field.attrAddr] = attr & ~FA.MDT;
         }
       }
     }
-
-    let modified = false;
-
-    // Parse orders and data
-    while (pos < data.length) {
-      const byte = data[pos];
-
-      switch (byte) {
-        case ORDER.SBA: {
-          // Set Buffer Address: 2 address bytes follow
-          if (pos + 2 >= data.length) return modified;
-          pos++;
-          const addr = decodeAddress(data[pos], data[pos + 1]);
-          pos += 2;
-          this.screen.currentAddr = addr % this.screen.size;
-          break;
-        }
-
-        case ORDER.SF: {
-          // Start Field: 1 attribute byte follows
-          if (pos + 1 >= data.length) return modified;
-          pos++;
-          const attr = data[pos++];
-          this.screen.setFieldAttribute(this.screen.currentAddr, attr);
-          this.screen.currentAddr = (this.screen.currentAddr + 1) % this.screen.size;
-          modified = true;
-          break;
-        }
-
-        case ORDER.SFE: {
-          // Start Field Extended: pair count, then (type, value) pairs
-          if (pos + 1 >= data.length) return modified;
-          pos++;
-          const pairCount = data[pos++];
-          let fieldAttr = 0;
-          let extHighlight = 0;
-          let extColor = 0;
-
-          for (let i = 0; i < pairCount && pos + 1 < data.length; i++) {
-            const attrType = data[pos++];
-            const attrValue = data[pos++];
-
-            if (attrType === 0xC0) {
-              // Basic field attribute
-              fieldAttr = attrValue;
-            } else if (attrType === EXT_ATTR.HIGHLIGHT) {
-              extHighlight = attrValue;
-            } else if (attrType === EXT_ATTR.COLOR) {
-              extColor = attrValue;
-            }
-            // Other extended attributes ignored for now
-          }
-
-          this.screen.setFieldAttribute(this.screen.currentAddr, fieldAttr || FA.PROTECTED);
-          this.screen.highlightBuffer[this.screen.currentAddr] = extHighlight;
-          this.screen.colorBuffer[this.screen.currentAddr] = extColor;
-          this.screen.currentAddr = (this.screen.currentAddr + 1) % this.screen.size;
-          modified = true;
-          break;
-        }
-
-        case ORDER.SA: {
-          // Set Attribute: type + value
-          if (pos + 2 >= data.length) return modified;
-          pos++;
-          const saType = data[pos++];
-          const saValue = data[pos++];
-          // SA affects subsequent characters until next SA/SF
-          if (saType === EXT_ATTR.HIGHLIGHT) {
-            this.screen.highlightBuffer[this.screen.currentAddr] = saValue;
-          } else if (saType === EXT_ATTR.COLOR) {
-            this.screen.colorBuffer[this.screen.currentAddr] = saValue;
-          }
-          break;
-        }
-
-        case ORDER.MF: {
-          // Modify Field: pair count, then (type, value) pairs
-          if (pos + 1 >= data.length) return modified;
-          pos++;
-          const mfPairCount = data[pos++];
-          for (let i = 0; i < mfPairCount && pos + 1 < data.length; i++) {
-            pos += 2; // Skip type + value
-          }
-          break;
-        }
-
-        case ORDER.IC: {
-          // Insert Cursor: set cursor to current buffer address
-          pos++;
-          this.screen.cursorAddr = this.screen.currentAddr;
-          break;
-        }
-
-        case ORDER.PT: {
-          // Program Tab: advance to next unprotected field
-          pos++;
-          this.advanceToNextUnprotected();
-          break;
-        }
-
-        case ORDER.RA: {
-          // Repeat to Address: 2 address bytes + 1 char byte
-          if (pos + 3 >= data.length) return modified;
-          pos++;
-          const targetAddr = decodeAddress(data[pos], data[pos + 1]);
-          pos += 2;
-          const charByte = data[pos++];
-
-          let repeatChar: string;
-          if (charByte === ORDER.GE && pos < data.length) {
-            // Graphic escape — next byte is an APL/graphic char
-            repeatChar = ebcdicToChar(data[pos++]);
-          } else {
-            repeatChar = ebcdicToChar(charByte);
-          }
-
-          const target = targetAddr % this.screen.size;
-          let addr = this.screen.currentAddr;
-          while (addr !== target) {
-            this.screen.setCharAt(addr, repeatChar);
-            addr = (addr + 1) % this.screen.size;
-          }
-          this.screen.currentAddr = target;
-          modified = true;
-          break;
-        }
-
-        case ORDER.EUA: {
-          // Erase Unprotected to Address: 2 address bytes
-          if (pos + 2 >= data.length) return modified;
-          pos++;
-          const euaTarget = decodeAddress(data[pos], data[pos + 1]);
-          pos += 2;
-
-          const euaEnd = euaTarget % this.screen.size;
-          let euaAddr = this.screen.currentAddr;
-          while (euaAddr !== euaEnd) {
-            // Only erase if position is in an unprotected field
-            const field = this.screen.getFieldAt(euaAddr);
-            if (field && !this.screen.isProtected(field)) {
-              this.screen.setCharAt(euaAddr, ' ');
-            }
-            euaAddr = (euaAddr + 1) % this.screen.size;
-          }
-          this.screen.currentAddr = euaEnd;
-          modified = true;
-          break;
-        }
-
-        case ORDER.GE: {
-          // Graphic Escape: next byte is a graphic character
-          pos++;
-          if (pos < data.length) {
-            const geChar = ebcdicToChar(data[pos++]);
-            this.screen.setCharAt(this.screen.currentAddr, geChar);
-            this.screen.currentAddr = (this.screen.currentAddr + 1) % this.screen.size;
-            modified = true;
-          }
-          break;
-        }
-
-        default: {
-          // Regular EBCDIC character data
-          const ch = ebcdicToChar(byte);
-          this.screen.setCharAt(this.screen.currentAddr, ch);
-          this.screen.currentAddr = (this.screen.currentAddr + 1) % this.screen.size;
-          pos++;
-          modified = true;
-          break;
-        }
-      }
+    if (wcc & WCC.KEYBOARD_RESTORE) {
+      this.screen.keyboardLocked = false;
     }
+    if (wcc & WCC.SOUND_ALARM) {
+      this.screen.pendingAlarm = true;
+    }
+  }
 
-    return modified;
+  /** Write one data byte: char + raw byte + any active SA character run. */
+  private writeData(addr: number, char: string, rawByte: number): void {
+    this.screen.setCharAt(addr, char, rawByte);
+    if (this.saHighlight !== 0 || this.saColor !== 0) {
+      const a = addr % this.screen.size;
+      if (this.saHighlight !== 0) this.screen.highlightBuffer[a] = this.saHighlight;
+      if (this.saColor !== 0) this.screen.colorBuffer[a] = this.saColor;
+    }
   }
 
   /** Parse structured fields */
@@ -285,7 +365,16 @@ export class TN3270Parser {
       const sfLen = (data[pos] << 8) | data[pos + 1];
       if (sfLen < 3 || pos + sfLen > data.length) break;
 
-      // Skip the structured field (we may implement query reply later)
+      const sfId = data[pos + 2];
+      // Read Partition (0x01) with type Query (0x02) / Query List (0x03):
+      // the host is probing device capabilities and waits for a Query Reply.
+      if (sfId === 0x01 && sfLen >= 5) {
+        const type = data[pos + 4];
+        if (type === 0x02 || type === 0x03) {
+          this.pendingQueryReply = true;
+        }
+      }
+
       pos += sfLen;
       modified = true;
     }
@@ -293,19 +382,19 @@ export class TN3270Parser {
     return modified;
   }
 
-  /** Advance cursor to the start of the next unprotected field */
+  /**
+   * Advance the buffer address past the next unprotected field attribute.
+   * Judged from the live attrBuffer (fields list is stale mid-record).
+   */
   private advanceToNextUnprotected(): void {
     const startAddr = this.screen.currentAddr;
     let addr = (startAddr + 1) % this.screen.size;
 
     while (addr !== startAddr) {
-      // Check if there's a field attribute at this position
-      if (this.screen.attrBuffer[addr] !== 0) {
-        const field = this.screen.fields.find(f => f.attrAddr === addr);
-        if (field && !this.screen.isProtected(field)) {
-          this.screen.currentAddr = field.startAddr;
-          return;
-        }
+      const attr = this.screen.attrBuffer[addr];
+      if (attr !== 0 && (attr & FA.PROTECTED) === 0) {
+        this.screen.currentAddr = (addr + 1) % this.screen.size;
+        return;
       }
       addr = (addr + 1) % this.screen.size;
     }

--- a/packages/proxy/src/tn3270/screen.ts
+++ b/packages/proxy/src/tn3270/screen.ts
@@ -1,5 +1,6 @@
 import { createHash } from 'node:crypto';
 import { AID, COLOR, FA, HIGHLIGHT, SCREEN } from './constants.js';
+import type { EbcdicCodePage } from '../encoding/ebcdic.js';
 import { computeStructuralSignature } from '../structural-signature.js';
 import type { Field, FieldColor } from 'green-screen-types';
 
@@ -65,6 +66,16 @@ export class ScreenBuffer3270 {
   /** AID of the last attention the client sent (for host-initiated reads). */
   lastAid: number = AID.NO_AID;
 
+  /** EBCDIC code page negotiated for this session (cp37 / cp1047 / ...). */
+  codePage: EbcdicCodePage = 'cp37';
+
+  /** Default (Erase/Write) dimensions — always Model 2's 24x80. */
+  defaultRows: number = SCREEN.MODEL_2_ROWS;
+  defaultCols: number = SCREEN.MODEL_2_COLS;
+  /** Alternate (Erase/Write Alternate) dimensions from the terminal model. */
+  altRows: number = SCREEN.MODEL_2_ROWS;
+  altCols: number = SCREEN.MODEL_2_COLS;
+
   constructor(rows = SCREEN.MODEL_2_ROWS, cols = SCREEN.MODEL_2_COLS) {
     this.rows = rows;
     this.cols = cols;
@@ -74,6 +85,36 @@ export class ScreenBuffer3270 {
     this.attrBuffer = new Array(size).fill(0);
     this.highlightBuffer = new Array(size).fill(0);
     this.colorBuffer = new Array(size).fill(0);
+  }
+
+  /** Configure default + alternate screen sizes (from the terminal model). */
+  configureSizes(altRows: number, altCols: number): void {
+    this.defaultRows = SCREEN.MODEL_2_ROWS;
+    this.defaultCols = SCREEN.MODEL_2_COLS;
+    this.altRows = altRows;
+    this.altCols = altCols;
+  }
+
+  /**
+   * Switch between default (Erase/Write) and alternate (EWA) screen sizes.
+   * Reallocates the buffers when dimensions change; callers always clear()
+   * right after (both erase commands imply it).
+   */
+  useAlternate(alt: boolean): void {
+    const rows = alt ? this.altRows : this.defaultRows;
+    const cols = alt ? this.altCols : this.defaultCols;
+    if (rows === this.rows && cols === this.cols) return;
+    this.rows = rows;
+    this.cols = cols;
+    const size = rows * cols;
+    this.buffer = new Array(size).fill(' ');
+    this.rawBuffer = new Uint8Array(size);
+    this.attrBuffer = new Array(size).fill(0);
+    this.highlightBuffer = new Array(size).fill(0);
+    this.colorBuffer = new Array(size).fill(0);
+    this.fields = [];
+    this.cursorAddr = 0;
+    this.currentAddr = 0;
   }
 
   get size(): number {

--- a/packages/proxy/src/tn3270/screen.ts
+++ b/packages/proxy/src/tn3270/screen.ts
@@ -2,7 +2,7 @@ import { createHash } from 'node:crypto';
 import { AID, COLOR, FA, HIGHLIGHT, SCREEN } from './constants.js';
 import type { EbcdicCodePage } from '../encoding/ebcdic.js';
 import { computeStructuralSignature } from '../structural-signature.js';
-import type { Field, FieldColor } from 'green-screen-types';
+import type { Field, FieldColor, FieldValue } from 'green-screen-types';
 
 export interface FieldDef3270 {
   /** Buffer address where the field attribute byte is */
@@ -68,6 +68,9 @@ export class ScreenBuffer3270 {
 
   /** EBCDIC code page negotiated for this session (cp37 / cp1047 / ...). */
   codePage: EbcdicCodePage = 'cp37';
+
+  /** Insert (vs overwrite) typing mode — client-side toggle, surfaced on the wire. */
+  insertMode: boolean = false;
 
   /** Default (Erase/Write) dimensions — always Model 2's 24x80. */
   defaultRows: number = SCREEN.MODEL_2_ROWS;
@@ -160,6 +163,7 @@ export class ScreenBuffer3270 {
     this.clear();
     this.keyboardLocked = false;
     this.pendingAlarm = false;
+    this.insertMode = false;
     this.lastAid = AID.NO_AID;
   }
 
@@ -237,6 +241,74 @@ export class ScreenBuffer3270 {
   /** Get the field at cursor position */
   getFieldAtCursor(): FieldDef3270 | null {
     return this.getFieldAt(this.cursorAddr);
+  }
+
+  /** 0-based offset of `addr` inside `field`, or -1 when outside it. */
+  offsetInField(field: FieldDef3270, addr: number): number {
+    const rel = (addr - field.startAddr + this.size) % this.size;
+    return rel < field.length ? rel : -1;
+  }
+
+  /** Set the MDT bit on a field (operator edit). */
+  markModified(field: FieldDef3270): void {
+    field.modified = true;
+    this.attrBuffer[field.attrAddr] |= FA.MDT;
+  }
+
+  /**
+   * Delete the character at `addr` inside `field`: shift the rest of the
+   * field left one cell, NUL-fill the last cell (3270 delete semantics).
+   */
+  deleteCharAt(field: FieldDef3270, addr: number): void {
+    const idx = this.offsetInField(field, addr);
+    if (idx < 0) return;
+    for (let i = idx; i < field.length - 1; i++) {
+      const dst = (field.startAddr + i) % this.size;
+      const src = (field.startAddr + i + 1) % this.size;
+      this.buffer[dst] = this.buffer[src];
+      this.rawBuffer[dst] = this.rawBuffer[src];
+    }
+    const last = (field.startAddr + field.length - 1) % this.size;
+    this.buffer[last] = ' ';
+    this.rawBuffer[last] = 0x00;
+    this.markModified(field);
+  }
+
+  /** Erase from `addr` to the end of `field` (Erase EOF): NUL fill + MDT. */
+  eraseToFieldEnd(field: FieldDef3270, addr: number): void {
+    const idx = this.offsetInField(field, addr);
+    if (idx < 0) return;
+    for (let i = idx; i < field.length; i++) {
+      const a = (field.startAddr + i) % this.size;
+      this.buffer[a] = ' ';
+      this.rawBuffer[a] = 0x00;
+    }
+    this.markModified(field);
+  }
+
+  /** Unprotected fields in buffer-address order (the Tab ring). */
+  inputFieldsInOrder(): FieldDef3270[] {
+    return this.fields
+      .filter((f) => !this.isProtected(f))
+      .sort((a, b) => a.startAddr - b.startAddr);
+  }
+
+  /** MDT read primitive — current text of input fields (see 5250 parity). */
+  readFieldValues(modifiedOnly: boolean = true): FieldValue[] {
+    const out: FieldValue[] = [];
+    for (const f of this.fields) {
+      if (this.isProtected(f)) continue;
+      if (modifiedOnly && !f.modified) continue;
+      const { row, col } = this.addrToRowCol(f.startAddr);
+      out.push({
+        row,
+        col,
+        length: f.length,
+        value: this.getFieldValue(f),
+        modified: f.modified,
+      });
+    }
+    return out;
   }
 
   /** Get field value as string */
@@ -339,6 +411,7 @@ export class ScreenBuffer3270 {
       screen_signature: hash,
       structural_signature: computeStructuralSignature(fields),
       keyboard_locked: this.keyboardLocked,
+      insert_mode: this.insertMode || undefined,
       alarm: alarm || undefined,
       timestamp: new Date().toISOString(),
     };

--- a/packages/proxy/src/tn3270/screen.ts
+++ b/packages/proxy/src/tn3270/screen.ts
@@ -1,5 +1,7 @@
-import { createHash } from 'crypto';
-import { FA, SCREEN } from './constants.js';
+import { createHash } from 'node:crypto';
+import { AID, COLOR, FA, HIGHLIGHT, SCREEN } from './constants.js';
+import { computeStructuralSignature } from '../structural-signature.js';
+import type { Field, FieldColor } from 'green-screen-types';
 
 export interface FieldDef3270 {
   /** Buffer address where the field attribute byte is */
@@ -17,11 +19,28 @@ export interface FieldDef3270 {
   modified: boolean;
 }
 
+/** 3270 COLOR attribute byte (0xF1–0xF7) → wire FieldColor. */
+const COLOR_BYTE_TO_NAME: Record<number, FieldColor> = {
+  [COLOR.BLUE]: 'blue',
+  [COLOR.RED]: 'red',
+  [COLOR.PINK]: 'pink',
+  [COLOR.GREEN]: 'green',
+  [COLOR.TURQUOISE]: 'turquoise',
+  [COLOR.YELLOW]: 'yellow',
+  [COLOR.WHITE]: 'white',
+};
+
 export class ScreenBuffer3270 {
   rows: number;
   cols: number;
   /** Character buffer (EBCDIC decoded to UTF-8) */
   buffer: string[];
+  /**
+   * Raw EBCDIC byte per position. 0x00 = NUL — distinct from 0x40 (space):
+   * Read Modified omits NULs, Read Buffer must reproduce them, and
+   * Erase/Write fills the buffer with NULs (displayed as blanks).
+   */
+  rawBuffer: Uint8Array;
   /** Field attribute at each position (0 = no field attribute here) */
   attrBuffer: number[];
   /** Extended highlight per cell */
@@ -35,11 +54,23 @@ export class ScreenBuffer3270 {
   /** Current buffer address for write operations */
   currentAddr: number = 0;
 
+  /**
+   * Input-inhibit state — locked while an AID round-trip is outstanding
+   * (set when the client transmits an AID, cleared by the host's WCC
+   * keyboard-restore bit or an Erase All Unprotected command).
+   */
+  keyboardLocked: boolean = false;
+  /** Pending audible alarm from WCC — one-shot, consumed by toScreenData(). */
+  pendingAlarm: boolean = false;
+  /** AID of the last attention the client sent (for host-initiated reads). */
+  lastAid: number = AID.NO_AID;
+
   constructor(rows = SCREEN.MODEL_2_ROWS, cols = SCREEN.MODEL_2_COLS) {
     this.rows = rows;
     this.cols = cols;
     const size = rows * cols;
     this.buffer = new Array(size).fill(' ');
+    this.rawBuffer = new Uint8Array(size); // NULs
     this.attrBuffer = new Array(size).fill(0);
     this.highlightBuffer = new Array(size).fill(0);
     this.colorBuffer = new Array(size).fill(0);
@@ -68,9 +99,10 @@ export class ScreenBuffer3270 {
     return row * this.cols + col;
   }
 
-  /** Clear entire screen */
+  /** Clear entire screen (Erase/Write): buffer becomes all NULs. */
   clear(): void {
     this.buffer.fill(' ');
+    this.rawBuffer.fill(0x00);
     this.attrBuffer.fill(0);
     this.highlightBuffer.fill(0);
     this.colorBuffer.fill(0);
@@ -79,23 +111,40 @@ export class ScreenBuffer3270 {
     this.currentAddr = 0;
   }
 
-  /** Clear all unprotected fields */
+  /**
+   * Full state reset for (re)connect — beyond clear(), also drops the
+   * input-inhibit/AID state that belongs to the previous session.
+   */
+  reset(): void {
+    this.clear();
+    this.keyboardLocked = false;
+    this.pendingAlarm = false;
+    this.lastAid = AID.NO_AID;
+  }
+
+  /** Clear all unprotected fields to NULs (Erase All Unprotected). */
   clearUnprotected(): void {
     for (const field of this.fields) {
       if (!this.isProtected(field)) {
         for (let i = 0; i < field.length; i++) {
           const addr = (field.startAddr + i) % this.size;
           this.buffer[addr] = ' ';
+          this.rawBuffer[addr] = 0x00;
         }
         field.modified = false;
+        this.attrBuffer[field.attrAddr] &= ~FA.MDT;
       }
     }
   }
 
-  /** Set character at buffer address */
-  setCharAt(addr: number, char: string): void {
+  /**
+   * Set character at buffer address. `rawByte` is the EBCDIC byte the
+   * position holds for host reads (0x00 keeps/creates a NUL position).
+   */
+  setCharAt(addr: number, char: string, rawByte: number): void {
     const a = addr % this.size;
     this.buffer[a] = char;
+    this.rawBuffer[a] = rawByte;
   }
 
   /** Get character at buffer address */
@@ -108,6 +157,7 @@ export class ScreenBuffer3270 {
     const a = addr % this.size;
     this.attrBuffer[a] = attr;
     this.buffer[a] = ' '; // attribute byte displays as space
+    this.rawBuffer[a] = 0x00;
   }
 
   /** Check if field is protected */
@@ -135,12 +185,10 @@ export class ScreenBuffer3270 {
     for (const field of this.fields) {
       const start = field.startAddr;
       const end = (start + field.length) % this.size;
-      if (start <= end) {
-        if (addr >= start && addr < end) return field;
-      } else {
-        // Field wraps around screen
-        if (addr >= start || addr < end) return field;
-      }
+      const inField = start <= end
+        ? addr >= start && addr < end
+        : addr >= start || addr < end; // field wraps around the screen
+      if (inField) return field;
     }
     return null;
   }
@@ -199,8 +247,8 @@ export class ScreenBuffer3270 {
         attrAddr,
         startAddr,
         attribute: this.attrBuffer[attrAddr],
-        extHighlight: 0,
-        extColor: 0,
+        extHighlight: this.highlightBuffer[attrAddr],
+        extColor: this.colorBuffer[attrAddr],
         length,
         modified: (this.attrBuffer[attrAddr] & FA.MDT) !== 0,
       });
@@ -216,21 +264,29 @@ export class ScreenBuffer3270 {
     }
     const content = lines.join('\n');
 
-    const fields = this.fields.map(f => {
+    const fields: Field[] = this.fields.map(f => {
       const { row, col } = this.addrToRowCol(f.startAddr);
+      const isInput = !this.isProtected(f);
       return {
         row,
         col,
         length: f.length,
-        is_input: !this.isProtected(f),
+        is_input: isInput,
         is_protected: this.isProtected(f),
         is_highlighted: this.isIntensified(f) || undefined,
-        is_reverse: undefined,
+        is_reverse: f.extHighlight === HIGHLIGHT.REVERSE || undefined,
+        is_underscored: f.extHighlight === HIGHLIGHT.UNDERSCORE || undefined,
         is_non_display: this.isHidden(f) || undefined,
+        is_numeric: this.isNumeric(f) || undefined,
+        color: COLOR_BYTE_TO_NAME[f.extColor],
+        modified: isInput ? f.modified : undefined,
       };
     });
 
     const hash = createHash('md5').update(content).digest('hex').substring(0, 12);
+    // Consume pending alarm (one-shot, same convention as 5250)
+    const alarm = this.pendingAlarm;
+    this.pendingAlarm = false;
 
     return {
       content,
@@ -240,6 +296,9 @@ export class ScreenBuffer3270 {
       cols: this.cols,
       fields,
       screen_signature: hash,
+      structural_signature: computeStructuralSignature(fields),
+      keyboard_locked: this.keyboardLocked,
+      alarm: alarm || undefined,
       timestamp: new Date().toISOString(),
     };
   }

--- a/packages/proxy/src/vt/connection.ts
+++ b/packages/proxy/src/vt/connection.ts
@@ -6,6 +6,7 @@ export interface VTConnectionOptions {
   terminalType?: string;
   rows?: number;
   cols?: number;
+  connectTimeout?: number;
 }
 
 /**
@@ -25,6 +26,13 @@ export class VTConnection extends EventEmitter {
   private rows: number = DEFAULT_ROWS;
   private cols: number = DEFAULT_COLS;
 
+  /** True once the server negotiated WILL ECHO (it owns the echo). */
+  private serverEchoes: boolean = false;
+
+  /** Liveness timestamps — same contract as the TN5250 connection. */
+  private lastRecvAtMs: number = 0;
+  private lastSendAtMs: number = 0;
+
   get isConnected(): boolean {
     return this.connected;
   }
@@ -37,6 +45,19 @@ export class VTConnection extends EventEmitter {
     return this.port;
   }
 
+  /** Whether the server negotiated WILL ECHO (no local echo needed). */
+  get remoteEcho(): boolean {
+    return this.serverEchoes;
+  }
+
+  get lastReceivedAtMs(): number {
+    return this.lastRecvAtMs;
+  }
+
+  get lastSentAtMs(): number {
+    return this.lastSendAtMs;
+  }
+
   connect(host: string, port: number, options?: VTConnectionOptions): Promise<void> {
     return new Promise((resolve, reject) => {
       if (this.socket) {
@@ -46,13 +67,14 @@ export class VTConnection extends EventEmitter {
       this.host = host;
       this.port = port;
       this.recvBuffer = Buffer.alloc(0);
+      this.serverEchoes = false;
 
       if (options?.terminalType) this.terminalType = options.terminalType;
       if (options?.rows) this.rows = options.rows;
       if (options?.cols) this.cols = options.cols;
 
       this.socket = new net.Socket();
-      this.socket.setTimeout(30000);
+      this.socket.setTimeout(options?.connectTimeout ?? 30000);
 
       const onError = (err: Error) => {
         this.cleanup();
@@ -63,7 +85,9 @@ export class VTConnection extends EventEmitter {
 
       this.socket.connect(port, host, () => {
         this.connected = true;
+        this.lastRecvAtMs = Date.now();
         this.socket!.removeListener('error', onError);
+        try { this.socket!.setKeepAlive(true, 30_000); } catch { /* ignore */ }
 
         this.socket!.on('error', (err) => {
           this.emit('error', err);
@@ -100,6 +124,7 @@ export class VTConnection extends EventEmitter {
   /** Send raw bytes over the socket */
   sendRaw(data: Buffer): void {
     if (this.socket && this.connected) {
+      this.lastSendAtMs = Date.now();
       this.socket.write(data);
     }
   }
@@ -114,6 +139,7 @@ export class VTConnection extends EventEmitter {
   }
 
   private onData(data: Buffer): void {
+    this.lastRecvAtMs = Date.now();
     this.recvBuffer = Buffer.concat([this.recvBuffer, data]);
     this.processBuffer();
   }
@@ -217,6 +243,7 @@ export class VTConnection extends EventEmitter {
           option === TELNET.OPT_SGA ||
           option === TELNET.OPT_BINARY
         ) {
+          if (option === TELNET.OPT_ECHO) this.serverEchoes = true;
           this.sendTelnet(TELNET.DO, option);
         } else {
           this.sendTelnet(TELNET.DONT, option);
@@ -228,6 +255,7 @@ export class VTConnection extends EventEmitter {
         break;
 
       case TELNET.WONT:
+        if (option === TELNET.OPT_ECHO) this.serverEchoes = false;
         this.sendTelnet(TELNET.DONT, option);
         break;
     }

--- a/packages/proxy/src/vt/constants.ts
+++ b/packages/proxy/src/vt/constants.ts
@@ -73,11 +73,15 @@ export const VT_KEYS: Record<string, string> = {
   F19: '\x1b[33~',
   F20: '\x1b[34~',
 
-  // Arrow keys
+  // Arrow keys (+ frontend ArrowX aliases, uppercased by encodeKey)
   UP: '\x1b[A',
   DOWN: '\x1b[B',
   RIGHT: '\x1b[C',
   LEFT: '\x1b[D',
+  ARROWUP: '\x1b[A',
+  ARROWDOWN: '\x1b[B',
+  ARROWRIGHT: '\x1b[C',
+  ARROWLEFT: '\x1b[D',
 
   // Editing keys
   HOME: '\x1b[1~',

--- a/packages/proxy/src/vt/encoder.ts
+++ b/packages/proxy/src/vt/encoder.ts
@@ -26,6 +26,16 @@ export class VTEncoder {
    */
   encodeKey(keyName: string): Buffer | null {
     const upper = keyName.toUpperCase();
+
+    // DECCKM: application cursor keys send SS3 (ESC O x) instead of CSI.
+    if (this.screen.applicationCursorKeys) {
+      const app: Record<string, string> = {
+        UP: '\x1bOA', DOWN: '\x1bOB', RIGHT: '\x1bOC', LEFT: '\x1bOD',
+        ARROWUP: '\x1bOA', ARROWDOWN: '\x1bOB', ARROWRIGHT: '\x1bOC', ARROWLEFT: '\x1bOD',
+      };
+      if (app[upper]) return Buffer.from(app[upper], 'binary');
+    }
+
     const seq = VT_KEYS[upper];
     if (seq) {
       return Buffer.from(seq, 'binary');

--- a/packages/proxy/src/vt/parser.test.ts
+++ b/packages/proxy/src/vt/parser.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import { VTScreenBuffer } from './screen.js';
+import { VTParser } from './parser.js';
+import { VTEncoder } from './encoder.js';
+
+function setup() {
+  const screen = new VTScreenBuffer();
+  const parser = new VTParser(screen);
+  const encoder = new VTEncoder(screen);
+  return { screen, parser, encoder };
+}
+
+function feedStr(parser: VTParser, text: string) {
+  parser.feed(Buffer.from(text, 'latin1'));
+}
+
+function row(screen: VTScreenBuffer, r: number): string {
+  const start = r * screen.cols;
+  return screen.buffer.slice(start, start + screen.cols).join('');
+}
+
+describe('VT charset designation', () => {
+  it('ESC ( B consumes the designator instead of printing a stray B', () => {
+    const { screen, parser } = setup();
+    feedStr(parser, '\x1b(BHello');
+    expect(row(screen, 0).trimEnd()).toBe('Hello'); // no leading 'B'
+  });
+
+  it('DEC Special Graphics (ESC ( 0) renders box-drawing glyphs', () => {
+    const { screen, parser } = setup();
+    feedStr(parser, '\x1b(0lqqk\x1b(B done');
+    expect(row(screen, 0)).toContain('┌──┐');
+    expect(row(screen, 0)).toContain('done'); // back to ASCII after ESC(B
+  });
+
+  it('SO/SI switch between G0 and G1 designations', () => {
+    const { screen, parser } = setup();
+    feedStr(parser, '\x1b)0'); // G1 = graphics
+    feedStr(parser, 'A\x0eq\x0fB'); // A, SO(graphics q = ─), SI, B
+    expect(row(screen, 0).slice(0, 3)).toBe('A─B');
+  });
+});
+
+describe('VT host probes (DA / DSR / CPR)', () => {
+  it('DA and DECID queue a VT220 identification reply', () => {
+    const { parser } = setup();
+    feedStr(parser, '\x1b[c');
+    feedStr(parser, '\x1bZ');
+    expect(parser.pendingResponses).toHaveLength(2);
+    expect(parser.pendingResponses[0].toString('latin1')).toBe('\x1b[?62;1;2;6;7;8;9c');
+  });
+
+  it('DSR 6 reports the cursor position 1-based (origin-mode relative)', () => {
+    const { screen, parser } = setup();
+    feedStr(parser, '\x1b[5;11H\x1b[6n');
+    expect(parser.pendingResponses.pop()!.toString('latin1')).toBe('\x1b[5;11R');
+
+    feedStr(parser, '\x1b[3;10r'); // region rows 3..10
+    feedStr(parser, '\x1b[?6h'); // origin mode: home = region top
+    feedStr(parser, '\x1b[2;4H\x1b[6n'); // row 2 within region = absolute row 4
+    expect(screen.cursorRow).toBe(3); // 0-based absolute
+    expect(parser.pendingResponses.pop()!.toString('latin1')).toBe('\x1b[2;4R');
+  });
+});
+
+describe('VT origin mode and scroll-region clamping', () => {
+  it('CUP with origin mode is region-relative and clamped inside the region', () => {
+    const { screen, parser } = setup();
+    feedStr(parser, '\x1b[5;20r\x1b[?6h');
+    feedStr(parser, '\x1b[1;1H');
+    expect(screen.cursorRow).toBe(4); // region top (0-based)
+    feedStr(parser, '\x1b[99;1H');
+    expect(screen.cursorRow).toBe(19); // clamped to region bottom
+  });
+
+  it('CUU stops at the scroll region top margin', () => {
+    const { screen, parser } = setup();
+    feedStr(parser, '\x1b[5;20r'); // no origin mode
+    feedStr(parser, '\x1b[10;1H\x1b[99A'); // cursor inside region, up 99
+    expect(screen.cursorRow).toBe(4); // stops at margin, not row 0
+  });
+});
+
+describe('VT alternate screen', () => {
+  it('1049 enter clears; exit restores the primary content and cursor', () => {
+    const { screen, parser } = setup();
+    feedStr(parser, 'primary text');
+    feedStr(parser, '\x1b[?1049h');
+    expect(row(screen, 0).trim()).toBe(''); // alt starts blank
+    feedStr(parser, 'ALT CONTENT');
+    feedStr(parser, '\x1b[?1049l');
+    expect(row(screen, 0)).toContain('primary text');
+    expect(row(screen, 0)).not.toContain('ALT');
+  });
+});
+
+describe('VT UTF-8 decoding', () => {
+  it('assembles multi-byte sequences split across feed() chunks', () => {
+    const { screen, parser } = setup();
+    parser.encoding = 'utf8';
+    const bytes = Buffer.from('héllo', 'utf8');
+    parser.feed(bytes.subarray(0, 2)); // 'h' + first byte of é
+    parser.feed(bytes.subarray(2));
+    expect(row(screen, 0).trimEnd()).toBe('héllo');
+  });
+
+  it('latin1 default preserves byte-for-byte behavior', () => {
+    const { screen, parser } = setup();
+    parser.feed(Buffer.from([0x41, 0xe9])); // 'A' + latin1 é
+    expect(row(screen, 0).slice(0, 2)).toBe('Aé');
+  });
+});
+
+describe('DECCKM application cursor keys', () => {
+  it('arrows switch to SS3 sequences when mode 1 is set', () => {
+    const { parser, encoder } = setup();
+    expect(encoder.encodeKey('ArrowUp')!.toString('latin1')).toBe('\x1b[A');
+    feedStr(parser, '\x1b[?1h');
+    expect(encoder.encodeKey('ArrowUp')!.toString('latin1')).toBe('\x1bOA');
+    expect(encoder.encodeKey('UP')!.toString('latin1')).toBe('\x1bOA');
+    feedStr(parser, '\x1b[?1l');
+    expect(encoder.encodeKey('ArrowDown')!.toString('latin1')).toBe('\x1b[B');
+  });
+});

--- a/packages/proxy/src/vt/parser.ts
+++ b/packages/proxy/src/vt/parser.ts
@@ -1,7 +1,7 @@
 import { VTScreenBuffer, defaultAttrs } from './screen.js';
 import { ESC, CSI_CHAR, BS, HT, LF, VT, FF, CR, SO, SI, BEL, SGR } from './constants.js';
 
-const State = { NORMAL: 0, ESC: 1, CSI_PARAM: 2, CSI_INTER: 3, OSC: 4, DCS: 5, SS2: 6, SS3: 7 } as const;
+const State = { NORMAL: 0, ESC: 1, CSI_PARAM: 2, CSI_INTER: 3, OSC: 4, DCS: 5, SS2: 6, SS3: 7, CHARSET: 8 } as const;
 type State = (typeof State)[keyof typeof State];
 
 /**
@@ -10,9 +10,42 @@ type State = (typeof State)[keyof typeof State];
  * Processes a stream of bytes from the host, interpreting control characters
  * and ANSI/VT escape sequences, and updating the screen buffer accordingly.
  */
+/** DEC Special Graphics (ESC ( 0) — bytes 0x60-0x7E render as line drawing. */
+const DEC_GRAPHICS: Record<number, string> = {
+  0x60: '◆', 0x61: '▒', 0x62: '␉', 0x63: '␌', 0x64: '␍', 0x65: '␊',
+  0x66: '°', 0x67: '±', 0x68: '␤', 0x69: '␋', 0x6a: '┘', 0x6b: '┐',
+  0x6c: '┌', 0x6d: '└', 0x6e: '┼', 0x6f: '⎺', 0x70: '⎻', 0x71: '─',
+  0x72: '⎼', 0x73: '⎽', 0x74: '├', 0x75: '┤', 0x76: '┴', 0x77: '┬',
+  0x78: '│', 0x79: '≤', 0x7a: '≥', 0x7b: 'π', 0x7c: '≠', 0x7d: '£',
+  0x7e: '·',
+};
+
+export type VTEncoding = 'latin1' | 'utf8';
+
 export class VTParser {
   private screen: VTScreenBuffer;
   private state: State = State.NORMAL;
+
+  /**
+   * Replies the host is waiting for (DA, DSR/CPR, DECID). The parser never
+   * writes to the socket — the handler flushes these after feed() (the same
+   * pending pattern as the block-mode protocols). Without CPR, cursor-probing
+   * full-screen apps (vim, less) hang or misdraw.
+   */
+  readonly pendingResponses: Buffer[] = [];
+
+  /** Byte→char decoding of printable data (default latin1 = old behavior). */
+  encoding: VTEncoding = 'latin1';
+  /** Partial UTF-8 sequence carried across feed() chunks. */
+  private utf8Pending: number[] = [];
+
+  /** G0/G1 charset designators ('B' ASCII, '0' DEC graphics, ...). */
+  private g0 = 'B';
+  private g1 = 'B';
+  /** Which of G0/G1 is active in GL (SI selects G0, SO selects G1). */
+  private glIsG1 = false;
+  /** Which G-set the pending ESC ( / ) designation targets. */
+  private designating: 'g0' | 'g1' | 'other' = 'g0';
 
   /** Accumulated CSI parameter string */
   private params: string = '';
@@ -65,6 +98,12 @@ export class VTParser {
         case State.SS2:
           this.state = State.NORMAL;
           break;
+        case State.CHARSET:
+          // Exactly one designator byte follows ESC ( / ) / * / +
+          if (this.designating === 'g0') this.g0 = String.fromCharCode(byte);
+          else if (this.designating === 'g1') this.g1 = String.fromCharCode(byte);
+          this.state = State.NORMAL;
+          break;
       }
     }
 
@@ -78,16 +117,47 @@ export class VTParser {
   private handleNormal(byte: number): boolean {
     // Control characters
     if (byte === ESC) {
+      this.utf8Pending.length = 0; // a control aborts any partial sequence
       this.state = State.ESC;
       return false;
     }
 
     if (byte < 0x20 || byte === 0x7f) {
+      this.utf8Pending.length = 0;
       return this.handleControlChar(byte);
+    }
+
+    // UTF-8 mode: assemble multi-byte sequences across feed() chunks.
+    if (this.encoding === 'utf8' && (byte >= 0x80 || this.utf8Pending.length > 0)) {
+      return this.handleUtf8Byte(byte);
+    }
+
+    // Active DEC Special Graphics set: 0x60-0x7E render as line drawing.
+    const active = this.glIsG1 ? this.g1 : this.g0;
+    if (active === '0' && byte >= 0x60 && byte <= 0x7e) {
+      this.screen.writeChar(DEC_GRAPHICS[byte] ?? String.fromCharCode(byte));
+      return true;
     }
 
     // Printable character — write to screen
     this.screen.writeChar(String.fromCharCode(byte));
+    return true;
+  }
+
+  private handleUtf8Byte(byte: number): boolean {
+    this.utf8Pending.push(byte);
+    const lead = this.utf8Pending[0];
+    const expected = lead >= 0xf0 ? 4 : lead >= 0xe0 ? 3 : lead >= 0xc0 ? 2 : 1;
+    if (expected === 1) {
+      // Continuation byte with no lead (or raw high byte) — render replacement.
+      this.utf8Pending.length = 0;
+      this.screen.writeChar('\ufffd');
+      return true;
+    }
+    if (this.utf8Pending.length < expected) return false; // wait for more
+    const decoded = Buffer.from(this.utf8Pending).toString('utf8');
+    this.utf8Pending.length = 0;
+    for (const ch of decoded) this.screen.writeChar(ch);
     return true;
   }
 
@@ -111,9 +181,11 @@ export class VTParser {
         this.screen.cursorCol = 0;
         this.screen.pendingWrap = false;
         return false;
-      case SO: // Shift Out — select G1 charset (simplified: ignore)
+      case SO: // Shift Out — G1 becomes the active GL set
+        this.glIsG1 = true;
         return false;
-      case SI: // Shift In — select G0 charset (simplified: ignore)
+      case SI: // Shift In — back to G0
+        this.glIsG1 = false;
         return false;
       case BEL: // Bell
         return false;
@@ -191,19 +263,23 @@ export class VTParser {
         this.state = State.NORMAL;
         return false;
 
-      case 0x28: // '(' — Designate G0 character set — consume next byte
-      case 0x29: // ')' — Designate G1 character set — consume next byte
-      case 0x2a: // '*' — Designate G2 character set
-      case 0x2b: // '+' — Designate G3 character set
-        // Next byte is the charset designator (B, 0, etc.) — ignore it
-        // We stay in a pseudo-state; simplification: just consume one more byte
-        // by not changing state. Actually we need to consume the next byte.
-        // Use a trick: stay in ESC state for one more byte? No — just go NORMAL
-        // and accept that we may misinterpret one character. For correctness,
-        // we handle it by noting this is a 3-byte sequence.
-        this.state = State.NORMAL; // next byte will be consumed as normal char
-        // This is a slight inaccuracy but charset switching is rarely
-        // semantically important for screen scraping.
+      case 0x28: // '(' — Designate G0 character set
+        this.designating = 'g0';
+        this.state = State.CHARSET;
+        return false;
+      case 0x29: // ')' — Designate G1 character set
+        this.designating = 'g1';
+        this.state = State.CHARSET;
+        return false;
+      case 0x2a: // '*' — Designate G2 (tracked but unused)
+      case 0x2b: // '+' — Designate G3
+        this.designating = 'other';
+        this.state = State.CHARSET;
+        return false;
+
+      case 0x5a: // 'Z' — DECID: answer like DA (VT220)
+        this.pendingResponses.push(Buffer.from('\x1b[?62;1;2;6;7;8;9c', 'latin1'));
+        this.state = State.NORMAL;
         return false;
 
       default:
@@ -276,12 +352,12 @@ export class VTParser {
 
     switch (finalChar) {
       // ------- Cursor movement -------
-      case 'A': // CUU — Cursor Up
-        this.screen.setCursor(this.screen.cursorRow - Math.max(p1, 1), this.screen.cursorCol);
+      case 'A': // CUU — Cursor Up (stops at the scroll region's top margin)
+        this.screen.cursorUp(Math.max(p1, 1));
         return false;
 
-      case 'B': // CUD — Cursor Down
-        this.screen.setCursor(this.screen.cursorRow + Math.max(p1, 1), this.screen.cursorCol);
+      case 'B': // CUD — Cursor Down (stops at the bottom margin)
+        this.screen.cursorDown(Math.max(p1, 1));
         return false;
 
       case 'C': // CUF — Cursor Forward
@@ -383,12 +459,21 @@ export class VTParser {
 
       // ------- Device status -------
       case 'n': // DSR — Device Status Report
-        // 6 = CPR (Cursor Position Report) — we'd need to send response
-        // For now, ignore
+        if (p1 === 5) {
+          this.pendingResponses.push(Buffer.from('\x1b[0n', 'latin1')); // "OK"
+        } else if (p1 === 6) {
+          // CPR — report the cursor position (1-based; origin-mode relative)
+          const row = this.screen.originMode
+            ? this.screen.cursorRow - this.screen.scrollTop + 1
+            : this.screen.cursorRow + 1;
+          this.pendingResponses.push(
+            Buffer.from(`\x1b[${row};${this.screen.cursorCol + 1}R`, 'latin1'),
+          );
+        }
         return false;
 
-      case 'c': // DA — Device Attributes
-        // Ignore — we'd need to send a response
+      case 'c': // DA — Device Attributes: VT220 with common capability set
+        this.pendingResponses.push(Buffer.from('\x1b[?62;1;2;6;7;8;9c', 'latin1'));
         return false;
 
       // ------- Tab -------
@@ -415,8 +500,8 @@ export class VTParser {
     switch (finalChar) {
       case 'h': // DECSET — Set DEC private mode
         switch (mode) {
-          case 1: // DECCKM — Application cursor keys (affects what arrow keys send)
-            // Tracked but no screen effect
+          case 1: // DECCKM — Application cursor keys (arrows send SS3)
+            this.screen.applicationCursorKeys = true;
             return false;
           case 6: // DECOM — Origin mode
             this.screen.originMode = true;
@@ -427,13 +512,13 @@ export class VTParser {
             return false;
           case 25: // DECTCEM — Show cursor (no visual effect in our buffer)
             return false;
-          case 1049: // Save cursor + switch to alternate screen buffer
+          case 1049: // Save cursor + switch to alternate screen buffer (clear)
             this.screen.saveCursor();
-            this.screen.eraseInDisplay(2);
+            this.screen.enterAlternateScreen();
             return true;
           case 47:
           case 1047: // Alternate screen buffer
-            this.screen.eraseInDisplay(2);
+            this.screen.enterAlternateScreen();
             return true;
         }
         return false;
@@ -441,6 +526,7 @@ export class VTParser {
       case 'l': // DECRST — Reset DEC private mode
         switch (mode) {
           case 1: // DECCKM — Normal cursor keys
+            this.screen.applicationCursorKeys = false;
             return false;
           case 6: // DECOM — Origin mode off
             this.screen.originMode = false;
@@ -451,11 +537,13 @@ export class VTParser {
             return false;
           case 25: // DECTCEM — Hide cursor
             return false;
-          case 1049: // Restore cursor + switch from alternate screen
+          case 1049: // Leave alternate screen + restore cursor
+            this.screen.exitAlternateScreen();
             this.screen.restoreCursor();
             return true;
           case 47:
           case 1047:
+            this.screen.exitAlternateScreen();
             return true;
         }
         return false;

--- a/packages/proxy/src/vt/screen.ts
+++ b/packages/proxy/src/vt/screen.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'crypto';
+import { createHash } from 'node:crypto';
 import { DEFAULT_ROWS, DEFAULT_COLS } from './constants.js';
 import type { ScreenData } from '../protocols/types.js';
 
@@ -78,8 +78,18 @@ export class VTScreenBuffer {
   /** Origin mode (DECOM) — cursor addressing relative to scroll region */
   originMode: boolean = false;
 
+  /** DECCKM — application cursor keys (arrows send SS3 instead of CSI) */
+  applicationCursorKeys: boolean = false;
+
   /** Pending wrap — the next printable char wraps to next line */
   pendingWrap: boolean = false;
+
+  /** Alternate-screen state: saved primary buffer while the alt is live. */
+  private savedPrimary: { buffer: string[]; attrs: CellAttrs[]; cursorRow: number; cursorCol: number } | null = null;
+
+  get inAlternateScreen(): boolean {
+    return this.savedPrimary !== null;
+  }
 
   constructor(rows = DEFAULT_ROWS, cols = DEFAULT_COLS) {
     this.rows = rows;
@@ -148,9 +158,33 @@ export class VTScreenBuffer {
   // Cursor movement
   // ---------------------------------------------------------------------------
 
+  /**
+   * Absolute cursor addressing (CUP/HVP/VPA...). With origin mode (DECOM)
+   * `row` is relative to the scroll region's top and the cursor is clamped
+   * inside the region.
+   */
   setCursor(row: number, col: number): void {
-    this.cursorRow = this.clampRow(row);
+    if (this.originMode) {
+      const r = this.scrollTop + Math.max(0, row);
+      this.cursorRow = Math.max(this.scrollTop, Math.min(this.scrollBottom, r));
+    } else {
+      this.cursorRow = this.clampRow(row);
+    }
     this.cursorCol = this.clampCol(col);
+    this.pendingWrap = false;
+  }
+
+  /** CUU — cursor up n, stopping at the scroll region's top margin. */
+  cursorUp(n: number): void {
+    const limit = this.cursorRow >= this.scrollTop ? this.scrollTop : 0;
+    this.cursorRow = Math.max(limit, this.cursorRow - n);
+    this.pendingWrap = false;
+  }
+
+  /** CUD — cursor down n, stopping at the scroll region's bottom margin. */
+  cursorDown(n: number): void {
+    const limit = this.cursorRow <= this.scrollBottom ? this.scrollBottom : this.rows - 1;
+    this.cursorRow = Math.min(limit, this.cursorRow + n);
     this.pendingWrap = false;
   }
 
@@ -344,6 +378,50 @@ export class VTScreenBuffer {
   }
 
   // ---------------------------------------------------------------------------
+  // Alternate screen (DECSET/DECRST 47 / 1047 / 1049)
+  // ---------------------------------------------------------------------------
+
+  /** Switch to the alternate screen: primary content saved, alt starts blank. */
+  enterAlternateScreen(): void {
+    if (this.savedPrimary) return; // already in alt
+    this.savedPrimary = {
+      buffer: this.buffer.slice(),
+      attrs: this.attrs.map((a) => ({ ...a })),
+      cursorRow: this.cursorRow,
+      cursorCol: this.cursorCol,
+    };
+    this.buffer.fill(' ');
+    for (let i = 0; i < this.size; i++) this.attrs[i] = defaultAttrs();
+  }
+
+  /** Leave the alternate screen: primary content and cursor restored. */
+  exitAlternateScreen(): void {
+    if (!this.savedPrimary) return;
+    this.buffer = this.savedPrimary.buffer;
+    this.attrs = this.savedPrimary.attrs;
+    this.cursorRow = this.savedPrimary.cursorRow;
+    this.cursorCol = this.savedPrimary.cursorCol;
+    this.savedPrimary = null;
+    this.pendingWrap = false;
+  }
+
+  /** Reallocate to new dimensions (session-negotiated size, not runtime). */
+  resize(rows: number, cols: number): void {
+    this.rows = rows;
+    this.cols = cols;
+    this.scrollTop = 0;
+    this.scrollBottom = rows - 1;
+    const size = rows * cols;
+    this.buffer = new Array(size).fill(' ');
+    this.attrs = new Array(size);
+    for (let i = 0; i < size; i++) this.attrs[i] = defaultAttrs();
+    this.cursorRow = 0;
+    this.cursorCol = 0;
+    this.pendingWrap = false;
+    this.savedPrimary = null;
+  }
+
+  // ---------------------------------------------------------------------------
   // Full reset
   // ---------------------------------------------------------------------------
 
@@ -359,8 +437,10 @@ export class VTScreenBuffer {
     this.currentAttrs = defaultAttrs();
     this.autoWrap = true;
     this.originMode = false;
+    this.applicationCursorKeys = false;
     this.pendingWrap = false;
     this.savedCursor = null;
+    this.savedPrimary = null;
   }
 
   // ---------------------------------------------------------------------------

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -36,8 +36,16 @@ export interface Field {
   is_underscored?: boolean;
   /** Whether the field is non-display (hidden input, e.g. password fields) */
   is_non_display?: boolean;
-  /** 5250 display color derived from the field attribute byte */
+  /** Display color derived from the field attribute byte (5250) or the
+   *  extended color attribute (3270 SFE/SA — COLOR bytes 0xF1–0xF7 map 1:1
+   *  onto this union). */
   color?: FieldColor;
+  /**
+   * Numeric-only input field. 3270: the field-attribute NUMERIC bit.
+   * 5250 exposes the richer `shift_type` instead ('numeric_only' /
+   * 'digits_only' / 'signed_num'); protocols without field typing omit it.
+   */
+  is_numeric?: boolean;
   /**
    * Highlight-on-entry attribute byte (FCW 0x89xx). When the cursor is
    * inside this field, the frontend should apply this attribute instead of


### PR DESCRIPTION
Protocol-maturation track (P4–P9) on top of the merged foundations (#14):

**TN3270 (the LegacyBridge automation carrier):**
- datastream semantics per GA23-0059: WCC bits fixed (keyboard restore/alarm/reset-MDT), SA character runs, MF, RA edge cases, EUA/PT judged from the live attribute buffer, NUL-vs-space raw tracking
- wire surface: `keyboard_locked`, one-shot `alarm`, `structural_signature`, field `color`/`is_reverse`/`is_underscored`/`modified` + new optional `Field.is_numeric` (types + client-py mirror, backward compatible)
- host-initiated reads answered: Read Buffer / Read Modified (All) / WSF Query Reply (previously the host waited forever)
- proper RFC 2355 TN3270E: device-type REQUEST/IS (+`-E` retry-on-reject), empty FUNCTIONS convergence, 5-byte headers both directions, SSCP-LU (VTAM USS) rendering, UNBIND event; framing moved to `connection.sendRecord`
- alternate screen sizes (Model 3/4/5 via EWA), codePage plumb-through (incl. new cp1047), liveness timestamps, `Heartbeat` → telnet TIMING-MARK probe
- full interactive editing: Tab/Backtab/Home/End/arrows/Backspace/Delete/Insert/Reset/EraseEOF, MDT on every edit, real `readFieldValues` (`traits.hasMdt`), autoskip

**VT:** charset-designation fix (no more leaked `B` artifacts), DEC Special Graphics, DA/DECID/DSR/CPR replies (vim/less no longer hang), origin mode + margin clamping, true alternate screen, opt-in UTF-8, DECCKM, options plumb-through, local-echo fallback, liveness.

**HP6530:** supported subset frozen + documented (`hp6530/README.md`), 13 conformance pins. No production changes (no NonStop emulator exists to verify against).

123 proxy tests + 12 client-py tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)