### PR TITLE
chore(release): v1.6.0 — align all five packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8830,7 +8830,7 @@
     },
     "packages/proxy": {
       "name": "green-screen-proxy",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "cors": "^2.8.5",
@@ -8852,7 +8852,7 @@
     },
     "packages/react": {
       "name": "green-screen-react",
-      "version": "1.4.0",
+      "version": "1.6.0",
       "license": "MIT",
       "devDependencies": {
         "@testing-library/jest-dom": "^6.6.3",
@@ -8874,33 +8874,19 @@
     },
     "packages/standalone": {
       "name": "green-screen-terminal",
-      "version": "1.4.0",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "express": "^4.21.0",
-        "green-screen-proxy": "^1.3.1"
+        "green-screen-proxy": "^1.6.0"
       },
       "bin": {
         "green-screen-terminal": "bin/green-screen-terminal.js"
       }
     },
-    "packages/standalone/node_modules/green-screen-proxy": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/green-screen-proxy/-/green-screen-proxy-1.3.1.tgz",
-      "integrity": "sha512-TZ32x4MitC91ZJ6oDITrvY24tIVrdgDEr/3bQeQgR0fxJgSgYsHNtq761ViWc0PW5P4jF1MeXqyGS+0NVV9FSA==",
-      "license": "MIT",
-      "dependencies": {
-        "cors": "^2.8.5",
-        "express": "^4.21.0",
-        "ws": "^8.18.0"
-      },
-      "bin": {
-        "green-screen-proxy": "dist/cli.js"
-      }
-    },
     "packages/types": {
       "name": "green-screen-types",
-      "version": "1.4.0",
+      "version": "1.6.0",
       "license": "MIT"
     }
   }

--- a/packages/client-py/pyproject.toml
+++ b/packages/client-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "green-screen-client"
-version = "1.5.0"
+version = "1.6.0"
 description = "Python client for green-screen-proxy — typed async REST + WebSocket adapter for TN5250/TN3270/VT/HP6530 terminal emulation"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "green-screen-proxy",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "WebSocket/REST proxy server for green-screen-react — connects browsers to TN5250, TN3270, VT220, and HP 6530 hosts over TCP",
   "type": "module",
   "bin": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "green-screen-react",
-  "version": "1.4.0",
+  "version": "1.6.0",
   "description": "Multi-protocol legacy terminal React component (TN5250, TN3270, VT, HP 6530)",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/standalone/package.json
+++ b/packages/standalone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "green-screen-terminal",
-  "version": "1.4.0",
+  "version": "1.6.0",
   "description": "Standalone web-based terminal for TN5250, TN3270, VT220, and HP 6530 hosts — run with npx green-screen-terminal",
   "type": "module",
   "bin": {
@@ -14,7 +14,7 @@
     "build:ui": "cd ../../apps/demo && VITE_BASE_URL=/ npx vite build --outDir ../../packages/standalone/ui"
   },
   "dependencies": {
-    "green-screen-proxy": "^1.3.1",
+    "green-screen-proxy": "^1.6.0",
     "express": "^4.21.0"
   },
   "keywords": [

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "green-screen-types",
-  "version": "1.4.0",
+  "version": "1.6.0",
   "description": "Shared type definitions for green-screen-react and green-screen-proxy",
   "type": "module",
   "main": "src/index.ts",


### PR DESCRIPTION
Converges types/react/standalone (1.4.0) and proxy/client-py (1.5.0) on **1.6.0** so publish.yml's all-versions-equal gate passes for the v1.6.0 tag. Bumps standalone's green-screen-proxy dep to ^1.6.0.

green-screen-types stays unpublished by design — consumed as type-only imports, fully erased from every published artifact.

After merge: tag v1.6.0 + GitHub release → npm (react/proxy/standalone) + PyPI (green-screen-client) publish workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)